### PR TITLE
Add GitHub Actions CI with Prettier check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run prettier:check
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "login": "devvit login",
     "prettier": "prettier --write .",
+    "prettier:check": "prettier --check .",
     "test": "vitest run",
     "type-check": "tsc --build"
   },

--- a/src/server/core/comment-cache.ts
+++ b/src/server/core/comment-cache.ts
@@ -106,10 +106,7 @@ type QueueItemRefreshResult = {
 };
 
 type CommentWithAuthor = HydratedComment<{ author: true }>;
-type CommentBodyPreview = Pick<
-  CommentEntity,
-  'bodyPreview'
->;
+type CommentBodyPreview = Pick<CommentEntity, 'bodyPreview'>;
 type CommentBodyMediaPreviewMarker =
   | typeof COMMENT_GIF_PREVIEW_MARKER
   | typeof COMMENT_IMAGE_PREVIEW_MARKER;


### PR DESCRIPTION
## Summary
- Add a `prettier:check` script for CI-safe formatting validation
- Add a GitHub Actions workflow that runs on PRs and pushes to `main`
- Include formatting, type check, lint, tests, and build in the CI job
- Normalize the `comment-cache` type formatting with Prettier

## Testing
- `npm run prettier:check`
- `npm run type-check`
- `npm run lint`
- `npm run test`
- `npm run build`