### PR TITLE
Add GitHub Actions CI and release publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run prettier:check
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,81 @@
+name: Publish Devvit App
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      DEVVIT_ALLOW_SOURCE_UPLOAD: '1'
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run prettier:check
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+      - name: Validate Devvit auth token
+        env:
+          DEVVIT_AUTH_TOKEN: ${{ secrets.DEVVIT_AUTH_TOKEN }}
+        run: |
+          if [ -z "$DEVVIT_AUTH_TOKEN" ]; then
+            echo "::error title=Missing Devvit auth token::Set the DEVVIT_AUTH_TOKEN repository secret before publishing releases."
+            exit 1
+          fi
+
+      - name: Derive Devvit version
+        id: version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error title=Invalid release tag::Release tag '$RELEASE_TAG' must be a stable semver tag like v1.2.3 or 1.2.3."
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Publish Devvit app
+        env:
+          DEVVIT_AUTH_TOKEN: ${{ secrets.DEVVIT_AUTH_TOKEN }}
+          DEVVIT_VERSION: ${{ steps.version.outputs.version }}
+        run: npm exec devvit -- publish --version "$DEVVIT_VERSION"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "login": "devvit login",
     "prettier": "prettier --write .",
+    "prettier:check": "prettier --check .",
     "test": "vitest run",
     "type-check": "tsc --build"
   },

--- a/src/server/core/comment-cache.ts
+++ b/src/server/core/comment-cache.ts
@@ -106,10 +106,7 @@ type QueueItemRefreshResult = {
 };
 
 type CommentWithAuthor = HydratedComment<{ author: true }>;
-type CommentBodyPreview = Pick<
-  CommentEntity,
-  'bodyPreview'
->;
+type CommentBodyPreview = Pick<CommentEntity, 'bodyPreview'>;
 type CommentBodyMediaPreviewMarker =
   | typeof COMMENT_GIF_PREVIEW_MARKER
   | typeof COMMENT_IMAGE_PREVIEW_MARKER;


### PR DESCRIPTION
## Summary
- Add a CI workflow that runs formatting, type-checking, linting, tests, and build on pushes and pull requests to `main`
- Add a release workflow that publishes the Devvit app from published GitHub releases using the release tag as the version
- Add a `prettier:check` script and a small TypeScript cleanup in the comment cache types

## Testing
- `npm run prettier:check`
- `npm run type-check`
- `npm run lint`
- `npm run test`
- `npm run build`