### PR TITLE
Add compact upvote formatting for axes and tooltips

### DIFF
--- a/src/client/charts/formatting.ts
+++ b/src/client/charts/formatting.ts
@@ -1,0 +1,8 @@
+const COMPACT_UPVOTE_FORMATTER = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+});
+
+export function formatCompactUpvoteCount(value: number): string {
+  return COMPACT_UPVOTE_FORMATTER.format(value);
+}

--- a/src/client/charts/options/common.ts
+++ b/src/client/charts/options/common.ts
@@ -1,5 +1,6 @@
 import type { ResolvedTheme } from '../../types';
 import type { EChartsCoreOption } from '../echarts';
+import { formatCompactUpvoteCount } from '../formatting';
 import { formatXAxisLabel } from '../timeAxis';
 import type {
   GetVisibleTimeRange,
@@ -11,6 +12,7 @@ export const SOAP_BUBBLE_FILL_ALPHA = 0.9;
 export const COMMENT_BUBBLE_FILL_ALPHA = 0.94;
 
 type TooltipVariant = 'light' | 'dark';
+type AxisLabelFormatter = (value: number) => string;
 
 export type ChartTheme = {
   mode: ResolvedTheme;
@@ -183,7 +185,7 @@ export function createUpvotesYAxis(theme = LIGHT_CHART_THEME) {
     axisTick: {
       show: false,
     },
-    axisLabel: createAxisLabel(theme),
+    axisLabel: createAxisLabel(theme, formatCompactUpvoteCount),
   };
 }
 
@@ -215,7 +217,7 @@ export function createValueAxis(
     axisTick: {
       show: false,
     },
-    axisLabel: createAxisLabel(theme),
+    axisLabel: createAxisLabel(theme, formatCompactUpvoteCount),
   };
 }
 
@@ -310,12 +312,17 @@ function createAxisLine(theme: ChartTheme) {
   };
 }
 
-function createAxisLabel(theme: ChartTheme) {
-  return {
+function createAxisLabel(
+  theme: ChartTheme,
+  formatter?: AxisLabelFormatter
+) {
+  const axisLabel = {
     color: theme.axisLabelColor,
     fontSize: 12,
     fontWeight: 600,
   };
+
+  return formatter ? { ...axisLabel, formatter } : axisLabel;
 }
 
 function createAxisNameTextStyle(theme: ChartTheme) {

--- a/src/client/charts/options/common.ts
+++ b/src/client/charts/options/common.ts
@@ -312,10 +312,7 @@ function createAxisLine(theme: ChartTheme) {
   };
 }
 
-function createAxisLabel(
-  theme: ChartTheme,
-  formatter?: AxisLabelFormatter
-) {
+function createAxisLabel(theme: ChartTheme, formatter?: AxisLabelFormatter) {
   const axisLabel = {
     color: theme.axisLabelColor,
     fontSize: 12,

--- a/src/client/charts/options/options.test.ts
+++ b/src/client/charts/options/options.test.ts
@@ -126,6 +126,51 @@ test('contributors option uses dual-axis zoom when enabled', () => {
   expect(readSeries(option).length).toBe(2);
 });
 
+test('upvote axes use compact tick labels', () => {
+  const datum = toPostBubbleDatum(post, 'alice');
+  const postsOption = createPostsOption([datum], metadata, false, false);
+  const commentsOption = createCommentsOption([], metadata, false, false);
+  const contributorsOption = createContributorsOption(
+    [
+      {
+        kind: 'contributor',
+        value: [1_200_000, -3_624, 7],
+        contributorName: 'Alice',
+        contributorAvatarUrl: null,
+        contributorSubredditKarmaBucket: 3,
+        postCount: 2,
+        commentCount: 5,
+        contributionCount: 7,
+        postScore: -3_624,
+        commentScore: 1_200_000,
+        profileUrl: '/user/Alice',
+        isCurrentUser: true,
+      },
+    ],
+    false,
+    false
+  );
+
+  expect(
+    formatAxisLabel(readObject(readOptionField(postsOption, 'yAxis')), 3_624)
+  ).toBe('3.6K');
+  expect(
+    formatAxisLabel(readObject(readOptionField(commentsOption, 'yAxis')), 2_000)
+  ).toBe('2K');
+  expect(
+    formatAxisLabel(
+      readObject(readOptionField(contributorsOption, 'xAxis')),
+      1_200_000
+    )
+  ).toBe('1.2M');
+  expect(
+    formatAxisLabel(
+      readObject(readOptionField(contributorsOption, 'yAxis')),
+      -3_624
+    )
+  ).toBe('-3.6K');
+});
+
 test('time charts use a narrow axis media override without changing contributors', () => {
   const datum = toPostBubbleDatum(post, 'alice');
   const expectedMedia = [
@@ -173,6 +218,22 @@ function readObject(value: unknown): Record<string, unknown> {
 function readLineColor(axis: Record<string, unknown>, key: string): unknown {
   const axisSection = readObject(axis[key]);
   return readObject(axisSection.lineStyle).color;
+}
+
+function formatAxisLabel(
+  axis: Record<string, unknown>,
+  value: number
+): unknown {
+  const axisLabel = readObject(axis.axisLabel);
+  const formatter = axisLabel.formatter;
+
+  expect(typeof formatter).toBe('function');
+
+  if (typeof formatter !== 'function') {
+    return null;
+  }
+
+  return formatter(value);
 }
 
 function readFirstSeriesColor(option: unknown, datum: unknown): string {

--- a/src/client/charts/tooltips.test.ts
+++ b/src/client/charts/tooltips.test.ts
@@ -5,8 +5,25 @@ import {
   COMMENT_IMAGE_PREVIEW_MARKER,
   USER_AVATAR_FALLBACK_URL,
 } from '../../shared/api';
-import { renderCommentTooltip, renderPostTooltip } from './tooltips';
-import type { CommentBubbleDatum, PostBubbleDatum } from './types';
+import { formatCompactUpvoteCount } from './formatting';
+import {
+  renderCommentTooltip,
+  renderContributorTooltip,
+  renderPostTooltip,
+} from './tooltips';
+import type {
+  CommentBubbleDatum,
+  ContributorBubbleDatum,
+  PostBubbleDatum,
+} from './types';
+
+test('formats compact upvote counts with stable en-US notation', () => {
+  expect(formatCompactUpvoteCount(999)).toBe('999');
+  expect(formatCompactUpvoteCount(2_000)).toBe('2K');
+  expect(formatCompactUpvoteCount(3_624)).toBe('3.6K');
+  expect(formatCompactUpvoteCount(-3_624)).toBe('-3.6K');
+  expect(formatCompactUpvoteCount(1_200_000)).toBe('1.2M');
+});
 
 test('renders escaped post tooltip content with fallback avatar and current-user badge', () => {
   vi.useFakeTimers();
@@ -60,6 +77,48 @@ test('renders dark themed post tooltip class when requested', () => {
   };
 
   expect(renderPostTooltip(datum, 'dark')).toMatch(/chart-tooltip--dark/);
+});
+
+test('renders compact tooltip upvotes while keeping count metrics exact', () => {
+  const postTooltip = renderPostTooltip(
+    createPostDatum({
+      score: 3_624,
+      comments: 2_000,
+      value: [Date.parse('2024-02-29T11:00:00.000Z'), 3_624],
+    })
+  );
+  const commentTooltip = renderCommentTooltip(
+    createCommentDatum({
+      score: 2_000,
+      value: [Date.parse('2024-02-29T11:00:00.000Z'), 2_000],
+    })
+  );
+  const contributorTooltip = renderContributorTooltip(
+    createContributorDatum({
+      postCount: 1_200,
+      commentCount: 2_300,
+      postScore: 3_624,
+      commentScore: 1_200_000,
+      value: [1_200_000, 3_624, 3_500],
+    })
+  );
+
+  expect(postTooltip).toContain('aria-label="3.6K upvotes"');
+  expect(postTooltip).toContain(
+    '<span class="chart-tooltip__metric-value">3.6K</span>'
+  );
+  expect(postTooltip).toContain('aria-label="2,000 comments"');
+  expect(postTooltip).toContain(
+    '<span class="chart-tooltip__metric-value">2,000</span>'
+  );
+  expect(commentTooltip).toContain('aria-label="2K upvotes"');
+  expect(commentTooltip).toContain(
+    '<span class="chart-tooltip__metric-value">2K</span>'
+  );
+  expect(contributorTooltip).toContain('aria-label="3.6K post upvotes"');
+  expect(contributorTooltip).toContain('aria-label="1.2M comment upvotes"');
+  expect(contributorTooltip).toContain('aria-label="1,200 posts"');
+  expect(contributorTooltip).toContain('aria-label="2,300 comments"');
 });
 
 test('renders escaped text comment tooltip content', () => {
@@ -126,6 +185,23 @@ test('renders mixed comment preview markers inline with escaped text', () => {
   expect(tooltip).not.toMatch(/giphy/);
 });
 
+const createPostDatum = (
+  overrides: Partial<PostBubbleDatum> = {}
+): PostBubbleDatum => ({
+  kind: 'post',
+  value: [Date.parse('2024-02-29T11:00:00.000Z'), 10],
+  score: 10,
+  comments: 2,
+  authorSubredditKarmaBucket: null,
+  title: 'Post',
+  authorName: 'Alice',
+  authorAvatarUrl: null,
+  createdAt: '2024-02-29T11:00:00.000Z',
+  permalink: '/r/example/comments/post-1',
+  isCurrentUser: false,
+  ...overrides,
+});
+
 const createCommentDatum = (
   overrides: Partial<CommentBubbleDatum> = {}
 ): CommentBubbleDatum => ({
@@ -138,6 +214,24 @@ const createCommentDatum = (
   createdAt: '2024-02-29T11:00:00.000Z',
   permalink: '/r/example/comments/post-1/comment-1',
   postId: 'post-1',
+  isCurrentUser: false,
+  ...overrides,
+});
+
+const createContributorDatum = (
+  overrides: Partial<ContributorBubbleDatum> = {}
+): ContributorBubbleDatum => ({
+  kind: 'contributor',
+  value: [30, 20, 7],
+  contributorName: 'Alice',
+  contributorAvatarUrl: null,
+  contributorSubredditKarmaBucket: 3,
+  postCount: 2,
+  commentCount: 5,
+  contributionCount: 7,
+  postScore: 20,
+  commentScore: 30,
+  profileUrl: '/user/Alice',
   isCurrentUser: false,
   ...overrides,
 });

--- a/src/client/charts/tooltips.ts
+++ b/src/client/charts/tooltips.ts
@@ -9,6 +9,7 @@ import TOOLTIP_POST_ICON from '../assets/icons/tooltip-post.svg?raw';
 import TOOLTIP_UPVOTE_ICON from '../assets/icons/tooltip-upvote.svg?raw';
 import { formatRelativeAge } from '../utils/date';
 import { escapeHtml } from '../utils/html';
+import { formatCompactUpvoteCount } from './formatting';
 import type {
   CommentBubbleDatum,
   ContributorBubbleDatum,
@@ -88,7 +89,8 @@ export function renderContributorTooltip(
     renderTooltipInlineLabeledMetric(
       TOOLTIP_UPVOTE_ICON,
       datum.postScore,
-      'post upvotes'
+      'post upvotes',
+      formatCompactUpvoteCount
     ),
     '</div>',
     '<div class="chart-tooltip__stats chart-tooltip__contributor-line">',
@@ -100,7 +102,8 @@ export function renderContributorTooltip(
     renderTooltipInlineLabeledMetric(
       TOOLTIP_UPVOTE_ICON,
       datum.commentScore,
-      'comment upvotes'
+      'comment upvotes',
+      formatCompactUpvoteCount
     ),
     '</div>',
     '</article>',
@@ -150,7 +153,7 @@ function renderMediaCommentTooltipLabel(label: string): string {
 }
 
 function renderTooltipVotePill(value: number, label = 'upvotes'): string {
-  const valueLabel = value.toLocaleString();
+  const valueLabel = formatCompactUpvoteCount(value);
 
   return `<span class="chart-tooltip__metric chart-tooltip__metric--pill chart-tooltip__metric--vote" aria-label="${escapeHtml(`${valueLabel} ${label}`)}">${TOOLTIP_UPVOTE_ICON}<span class="chart-tooltip__metric-value">${valueLabel}</span>${TOOLTIP_DOWNVOTE_ICON}</span>`;
 }
@@ -165,7 +168,7 @@ function renderTooltipInlineVoteMetric(
   value: number,
   label = 'upvotes'
 ): string {
-  const valueLabel = value.toLocaleString();
+  const valueLabel = formatCompactUpvoteCount(value);
 
   return `<span class="chart-tooltip__metric chart-tooltip__metric--inline-vote" aria-label="${escapeHtml(`${valueLabel} ${label}`)}">${TOOLTIP_UPVOTE_ICON}<span class="chart-tooltip__metric-value">${valueLabel}</span>${TOOLTIP_DOWNVOTE_ICON}</span>`;
 }
@@ -173,9 +176,11 @@ function renderTooltipInlineVoteMetric(
 function renderTooltipInlineLabeledMetric(
   icon: string,
   value: number,
-  label: string
+  label: string,
+  formatValue: (value: number) => string = (metricValue) =>
+    metricValue.toLocaleString()
 ): string {
-  const valueLabel = value.toLocaleString();
+  const valueLabel = formatValue(value);
 
   return `<span class="chart-tooltip__metric chart-tooltip__metric--inline-labeled" aria-label="${escapeHtml(`${valueLabel} ${label}`)}">${icon}<span class="chart-tooltip__metric-value">${valueLabel}</span><span class="chart-tooltip__metric-label">${escapeHtml(label)}</span></span>`;
 }


### PR DESCRIPTION
## Summary
- Format upvote axis labels with compact `K`/`M` notation across posts, comments, and contributors.
- Apply the same compact formatting to upvote tooltip values and matching accessibility labels.
- Keep non-upvote counts exact and comma-formatted.

## Testing
- `npm run test -- src/client/charts/options/options.test.ts src/client/charts/tooltips.test.ts`
- `npm run type-check`
- `npm run lint`
- `npm test`