### PR TITLE
Limit chart zoom to 8x and reset from the multiplier label

### DIFF
--- a/src/client/charts/options/comments.ts
+++ b/src/client/charts/options/comments.ts
@@ -45,7 +45,7 @@ export function createCommentsOption(
         ? renderCommentTooltip(datum, chartTheme.tooltipVariant)
         : '';
     }, chartTheme),
-    dataZoom: createSingleAxisDataZoom(10),
+    dataZoom: createSingleAxisDataZoom(),
     xAxis: createTimeXAxis(startTime, endTime, getVisibleTimeRange, chartTheme),
     yAxis: {
       ...createUpvotesYAxis(chartTheme),

--- a/src/client/charts/options/common.ts
+++ b/src/client/charts/options/common.ts
@@ -9,6 +9,7 @@ import type {
   RippleColorOption,
   SymbolSizeOption,
 } from '../types';
+import { CHART_MAX_ZOOM_MIN_SPAN } from '../zoom';
 
 export const SOAP_BUBBLE_FILL_ALPHA = 0.9;
 export const COMMENT_BUBBLE_FILL_ALPHA = 0.94;
@@ -226,7 +227,7 @@ export function createValueAxis(
 }
 
 export function createSingleAxisDataZoom(
-  minSpan: number
+  minSpan = CHART_MAX_ZOOM_MIN_SPAN
 ): DataZoomComponentOption {
   return {
     type: 'inside',

--- a/src/client/charts/options/contributors.ts
+++ b/src/client/charts/options/contributors.ts
@@ -62,7 +62,7 @@ export function createContributorsOption(
     backgroundColor: chartTheme.backgroundColor,
     darkMode: chartTheme.mode === 'dark',
     grid: createChartGrid({ right: CONTRIBUTOR_GRID_RIGHT }),
-    dataZoom: createSingleAxisDataZoom(10),
+    dataZoom: createSingleAxisDataZoom(),
     tooltip: createChartTooltip((params) => {
       const datum = isContributorBubbleDatum(params.data) ? params.data : null;
       return datum

--- a/src/client/charts/options/options.test.ts
+++ b/src/client/charts/options/options.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest';
 
 import type { ChartResponseMetadata, ChartPost } from '../../../shared/api';
 import { toPostBubbleDatum } from '../data';
+import { CHART_MAX_ZOOM_MIN_SPAN } from '../zoom';
 import { createCommentsOption } from './comments';
 import { createContributorsOption } from './contributors';
 import { getChartTheme } from './common';
@@ -34,14 +35,14 @@ test('posts option uses initially idle zoom and toggles current-user ripple seri
   const option = createPostsOption(data, metadata, true);
 
   expect(readOptionField(option, 'dataZoom')).toEqual(
-    createExpectedSingleAxisDataZoom(10)
+    createExpectedSingleAxisDataZoom(CHART_MAX_ZOOM_MIN_SPAN)
   );
   expect(readSeries(option).length).toBe(2);
 
   const noRippleOption = createPostsOption(data, metadata, false);
 
   expect(readOptionField(noRippleOption, 'dataZoom')).toEqual(
-    createExpectedSingleAxisDataZoom(10)
+    createExpectedSingleAxisDataZoom(CHART_MAX_ZOOM_MIN_SPAN)
   );
   expect(readSeries(noRippleOption).length).toBe(1);
   expect(readOptionField(noRippleOption, 'darkMode')).toBe(false);
@@ -51,7 +52,7 @@ test('comments option uses initially idle single-axis zoom', () => {
   const option = createCommentsOption([], metadata, false);
 
   expect(readOptionField(option, 'dataZoom')).toEqual(
-    createExpectedSingleAxisDataZoom(10)
+    createExpectedSingleAxisDataZoom(CHART_MAX_ZOOM_MIN_SPAN)
   );
 });
 
@@ -156,7 +157,9 @@ test('contributors option uses posts-style grid and x-axis zoom', () => {
   expect(yAxis.max).toBe(undefined);
   expectAxisNameHidden(xAxis);
   expectAxisNameHidden(yAxis);
-  expect(dataZoom).toEqual(createExpectedSingleAxisDataZoom(10));
+  expect(dataZoom).toEqual(
+    createExpectedSingleAxisDataZoom(CHART_MAX_ZOOM_MIN_SPAN)
+  );
   expect(readSeries(option).length).toBe(2);
 });
 

--- a/src/client/charts/options/posts.ts
+++ b/src/client/charts/options/posts.ts
@@ -54,7 +54,7 @@ export function createPostsOption(
       const datum = isPostBubbleDatum(params.data) ? params.data : null;
       return datum ? renderPostTooltip(datum, chartTheme.tooltipVariant) : '';
     }, chartTheme),
-    dataZoom: createSingleAxisDataZoom(10),
+    dataZoom: createSingleAxisDataZoom(),
     xAxis: createTimeXAxis(startTime, endTime, getVisibleTimeRange, chartTheme),
     yAxis: {
       ...createUpvotesYAxis(chartTheme),

--- a/src/client/charts/zoom.test.ts
+++ b/src/client/charts/zoom.test.ts
@@ -2,64 +2,120 @@ import { SVGRenderer } from 'echarts/renderers';
 import { expect, test } from 'vitest';
 
 import { echarts } from './echarts';
-import { calculateZoomRange, zoomChart } from './zoom';
+import {
+  CHART_MAX_ZOOM_MIN_SPAN,
+  calculateZoomMultiplier,
+  calculateZoomRange,
+  readChartZoomMultiplier,
+  resetChartZoom,
+  zoomChart,
+} from './zoom';
 
 echarts.use([SVGRenderer]);
 
 test('zooms in from the full range', () => {
-  expect(calculateZoomRange({ start: 0, end: 100, minSpan: 10 }, 'in')).toEqual(
-    {
-      start: 15,
-      end: 85,
-      minSpan: 10,
-    }
-  );
+  expect(
+    calculateZoomRange(
+      { start: 0, end: 100, minSpan: CHART_MAX_ZOOM_MIN_SPAN },
+      'in'
+    )
+  ).toEqual({
+    start: 25,
+    end: 75,
+    minSpan: CHART_MAX_ZOOM_MIN_SPAN,
+  });
 });
 
-test('zooms out from a partial range', () => {
-  const range = calculateZoomRange({ start: 25, end: 75, minSpan: 10 }, 'out');
+test('zooms in through fixed multipliers', () => {
+  expect(
+    calculateZoomRange(
+      { start: 25, end: 75, minSpan: CHART_MAX_ZOOM_MIN_SPAN },
+      'in'
+    )
+  ).toEqual({
+    start: 37.5,
+    end: 62.5,
+    minSpan: CHART_MAX_ZOOM_MIN_SPAN,
+  });
+  expect(
+    calculateZoomRange(
+      { start: 37.5, end: 62.5, minSpan: CHART_MAX_ZOOM_MIN_SPAN },
+      'in'
+    )
+  ).toEqual({
+    start: 43.75,
+    end: 56.25,
+    minSpan: CHART_MAX_ZOOM_MIN_SPAN,
+  });
+});
 
-  expect(range.start).toBeCloseTo(14.285714);
-  expect(range.end).toBeCloseTo(85.714286);
-  expect(range.minSpan).toBe(10);
+test('zooms out through fixed multipliers', () => {
+  expect(
+    calculateZoomRange(
+      { start: 37.5, end: 62.5, minSpan: CHART_MAX_ZOOM_MIN_SPAN },
+      'out'
+    )
+  ).toEqual({
+    start: 25,
+    end: 75,
+    minSpan: CHART_MAX_ZOOM_MIN_SPAN,
+  });
 });
 
 test('clamps zoom out at the full range', () => {
   expect(
-    calculateZoomRange({ start: 0, end: 100, minSpan: 10 }, 'out')
+    calculateZoomRange(
+      { start: 0, end: 100, minSpan: CHART_MAX_ZOOM_MIN_SPAN },
+      'out'
+    )
   ).toEqual({
     start: 0,
     end: 100,
-    minSpan: 10,
+    minSpan: CHART_MAX_ZOOM_MIN_SPAN,
   });
 });
 
-test('snaps zoom out to the full range near the end', () => {
-  expect(calculateZoomRange({ start: 2, end: 95, minSpan: 10 }, 'out')).toEqual(
-    {
-      start: 0,
-      end: 100,
-      minSpan: 10,
-    }
-  );
-});
-
-test('respects minimum span while zooming in', () => {
-  expect(calculateZoomRange({ start: 20, end: 31, minSpan: 10 }, 'in')).toEqual(
-    {
-      start: 20.5,
-      end: 30.5,
-      minSpan: 10,
-    }
-  );
+test('clamps zoom in at 8x', () => {
+  expect(
+    calculateZoomRange(
+      { start: 43.75, end: 56.25, minSpan: CHART_MAX_ZOOM_MIN_SPAN },
+      'in'
+    )
+  ).toEqual({
+    start: 43.75,
+    end: 56.25,
+    minSpan: CHART_MAX_ZOOM_MIN_SPAN,
+  });
 });
 
 test('preserves centered ranges near edges when possible', () => {
-  expect(calculateZoomRange({ start: 5, end: 25, minSpan: 0 }, 'in')).toEqual({
-    start: 8,
-    end: 22,
-    minSpan: 0,
+  expect(
+    calculateZoomRange(
+      { start: 0, end: 50, minSpan: CHART_MAX_ZOOM_MIN_SPAN },
+      'in'
+    )
+  ).toEqual({
+    start: 12.5,
+    end: 37.5,
+    minSpan: CHART_MAX_ZOOM_MIN_SPAN,
   });
+});
+
+test('hides zoom multiplier at the full range', () => {
+  expect(calculateZoomMultiplier([{ start: 0, end: 100 }])).toBeNull();
+});
+
+test('calculates zoom multiplier from the visible range', () => {
+  expect(calculateZoomMultiplier([{ start: 25, end: 75 }])).toBe(2);
+});
+
+test('uses the most zoomed range for zoom multiplier', () => {
+  expect(
+    calculateZoomMultiplier([
+      { start: 0, end: 100 },
+      { start: 37.5, end: 62.5 },
+    ])
+  ).toBe(4);
 });
 
 test('enables pan after zooming in and disables pan at full range', () => {
@@ -79,7 +135,7 @@ test('enables pan after zooming in and disables pan at full range', () => {
           xAxisIndex: 0,
           start: 0,
           end: 100,
-          minSpan: 10,
+          minSpan: CHART_MAX_ZOOM_MIN_SPAN,
           disabled: true,
           zoomLock: true,
           zoomOnMouseWheel: false,
@@ -92,7 +148,7 @@ test('enables pan after zooming in and disables pan at full range', () => {
           yAxisIndex: 0,
           start: 0,
           end: 100,
-          minSpan: 10,
+          minSpan: CHART_MAX_ZOOM_MIN_SPAN,
           disabled: true,
           zoomLock: true,
           zoomOnMouseWheel: false,
@@ -114,7 +170,10 @@ test('enables pan after zooming in and disables pan at full range', () => {
       series: [],
     });
 
+    expect(readChartZoomMultiplier(chart)).toBeNull();
+
     zoomChart(chart, 'in');
+    expect(readChartZoomMultiplier(chart)).toBe(2);
 
     const dataZoom = chart.getOption().dataZoom;
     expect(Array.isArray(dataZoom)).toBe(true);
@@ -123,20 +182,24 @@ test('enables pan after zooming in and disables pan at full range', () => {
       return;
     }
 
-    expect(readOptionNumber(dataZoom[0], 'start')).toBe(15);
-    expect(readOptionNumber(dataZoom[0], 'end')).toBe(85);
+    expect(readOptionNumber(dataZoom[0], 'start')).toBe(25);
+    expect(readOptionNumber(dataZoom[0], 'end')).toBe(75);
     expect(readOptionNumber(dataZoom[0], 'xAxisIndex')).toBe(0);
+    expect(readOptionNumber(dataZoom[0], 'minSpan')).toBe(
+      CHART_MAX_ZOOM_MIN_SPAN
+    );
     expect(readOptionBoolean(dataZoom[0], 'disabled')).toBe(false);
     expect(readOptionBoolean(dataZoom[0], 'moveOnMouseMove')).toBe(true);
     expect(readOptionBoolean(dataZoom[0], 'preventDefaultMouseMove')).toBe(
       true
     );
-    expect(readOptionNumber(dataZoom[1], 'start')).toBe(15);
-    expect(readOptionNumber(dataZoom[1], 'end')).toBe(85);
+    expect(readOptionNumber(dataZoom[1], 'start')).toBe(25);
+    expect(readOptionNumber(dataZoom[1], 'end')).toBe(75);
     expect(readOptionNumber(dataZoom[1], 'yAxisIndex')).toBe(0);
     expect(readOptionBoolean(dataZoom[1], 'disabled')).toBe(false);
 
-    zoomChart(chart, 'out');
+    resetChartZoom(chart);
+    expect(readChartZoomMultiplier(chart)).toBeNull();
 
     const resetDataZoom = chart.getOption().dataZoom;
     expect(Array.isArray(resetDataZoom)).toBe(true);

--- a/src/client/charts/zoom.ts
+++ b/src/client/charts/zoom.ts
@@ -15,11 +15,13 @@ type DataZoomRangeSnapshot = {
   minSpan: number;
 };
 
-const CHART_ZOOM_IN_FACTOR = 0.7;
-const ZOOM_OUT_FULL_RANGE_THRESHOLD = 96;
-const FULL_RANGE_TOLERANCE = 0.001;
 const MIN_PERCENT = 0;
 const MAX_PERCENT = 100;
+export const CHART_MAX_ZOOM_MULTIPLIER = 8;
+export const CHART_MAX_ZOOM_MIN_SPAN = MAX_PERCENT / CHART_MAX_ZOOM_MULTIPLIER;
+const FULL_RANGE_TOLERANCE = 0.001;
+const ZOOM_MULTIPLIERS = [1, 2, 4, CHART_MAX_ZOOM_MULTIPLIER];
+const REVERSED_ZOOM_MULTIPLIERS = [CHART_MAX_ZOOM_MULTIPLIER, 4, 2, 1];
 
 export function zoomChart(
   chart: EChartsInstance,
@@ -47,22 +49,71 @@ export function zoomChart(
   syncDataZoomPan(chart, nextRanges);
 }
 
+export function resetChartZoom(chart: EChartsInstance): void {
+  const dataZoomRanges = collectDataZoomRanges(chart.getOption().dataZoom);
+  if (dataZoomRanges.length === 0) {
+    return;
+  }
+
+  const nextRanges = dataZoomRanges.map(({ dataZoomIndex }) => ({
+    dataZoomIndex,
+    start: MIN_PERCENT,
+    end: MAX_PERCENT,
+  }));
+
+  chart.dispatchAction({
+    type: 'dataZoom',
+    batch: nextRanges,
+  });
+  syncDataZoomPan(chart, nextRanges);
+}
+
+export function readChartZoomMultiplier(chart: EChartsInstance): number | null {
+  return calculateZoomMultiplier(
+    collectDataZoomRanges(chart.getOption().dataZoom)
+  );
+}
+
+export function calculateZoomMultiplier(
+  ranges: readonly ZoomRange[]
+): number | null {
+  const spans = ranges.map(({ start, end }) => {
+    const normalizedStart = clampPercent(Math.min(start, end));
+    const normalizedEnd = clampPercent(Math.max(start, end));
+
+    return normalizedEnd - normalizedStart;
+  });
+
+  if (
+    spans.length === 0 ||
+    spans.every((span) => span >= MAX_PERCENT - FULL_RANGE_TOLERANCE)
+  ) {
+    return null;
+  }
+
+  const visibleSpan = Math.max(Math.min(...spans), FULL_RANGE_TOLERANCE);
+  const zoomMultiplier = MAX_PERCENT / visibleSpan;
+
+  return findNearestVisibleZoomMultiplier(zoomMultiplier);
+}
+
 export function calculateZoomRange(
   range: ZoomRange,
   direction: ChartZoomDirection
 ): ZoomRange {
   const start = clampPercent(Math.min(range.start, range.end));
   const end = clampPercent(Math.max(range.start, range.end));
-  const minSpan = clampPercent(range.minSpan ?? MIN_PERCENT);
-  const currentSpan = Math.max(end - start, minSpan);
-  const targetSpan =
-    direction === 'in'
-      ? currentSpan * CHART_ZOOM_IN_FACTOR
-      : currentSpan / CHART_ZOOM_IN_FACTOR;
+  const minSpan = calculateEffectiveMinSpan(range.minSpan);
+  const currentSpan = clamp(end - start, minSpan, MAX_PERCENT);
+  const currentMultiplier = MAX_PERCENT / currentSpan;
+  const nextMultiplier = calculateNextZoomMultiplier(
+    currentMultiplier,
+    direction
+  );
   const nextSpan =
-    direction === 'out' && targetSpan >= ZOOM_OUT_FULL_RANGE_THRESHOLD
+    nextMultiplier === 1
       ? MAX_PERCENT
-      : clamp(targetSpan, minSpan, MAX_PERCENT);
+      : Math.max(MAX_PERCENT / nextMultiplier, minSpan);
   const center = (start + end) / 2;
 
   return createCenteredRange(center, nextSpan, minSpan);
@@ -84,6 +135,7 @@ function syncDataZoomPan(
       type: 'inside',
       start,
       end,
+      minSpan: CHART_MAX_ZOOM_MIN_SPAN,
       disabled: !panEnabled,
       zoomLock: true,
       zoomOnMouseWheel: false,
@@ -120,6 +172,44 @@ function readDataZoomRange(
     end: clampPercent(readFiniteNumber(value, 'end') ?? MAX_PERCENT),
     minSpan: clampPercent(readFiniteNumber(value, 'minSpan') ?? MIN_PERCENT),
   };
+}
+
+function calculateNextZoomMultiplier(
+  currentMultiplier: number,
+  direction: ChartZoomDirection
+): number {
+  if (direction === 'in') {
+    for (const zoomMultiplier of ZOOM_MULTIPLIERS) {
+      if (zoomMultiplier > currentMultiplier + FULL_RANGE_TOLERANCE) {
+        return zoomMultiplier;
+      }
+    }
+
+    return CHART_MAX_ZOOM_MULTIPLIER;
+  }
+
+  for (const zoomMultiplier of REVERSED_ZOOM_MULTIPLIERS) {
+    if (zoomMultiplier < currentMultiplier - FULL_RANGE_TOLERANCE) {
+      return zoomMultiplier;
+    }
+  }
+
+  return 1;
+}
+
+function findNearestVisibleZoomMultiplier(currentMultiplier: number): number {
+  return ZOOM_MULTIPLIERS.slice(1).reduce((nearest, zoomMultiplier) => {
+    const nearestDistance = Math.abs(currentMultiplier - nearest);
+    const zoomMultiplierDistance = Math.abs(currentMultiplier - zoomMultiplier);
+
+    return zoomMultiplierDistance < nearestDistance ? zoomMultiplier : nearest;
+  }, 2);
+}
+
+function calculateEffectiveMinSpan(minSpan: number | undefined): number {
+  const normalizedMinSpan = clampPercent(minSpan ?? CHART_MAX_ZOOM_MIN_SPAN);
+
+  return Math.min(normalizedMinSpan, CHART_MAX_ZOOM_MIN_SPAN);
 }
 
 function createCenteredRange(

--- a/src/client/components/ChartZoomControls.tsx
+++ b/src/client/components/ChartZoomControls.tsx
@@ -1,13 +1,56 @@
-import type { RefObject } from 'react';
+import { useEffect, useState, type RefObject } from 'react';
 
 import type { EChartsInstance } from '../charts/echarts';
-import { zoomChart, type ChartZoomDirection } from '../charts/zoom';
+import {
+  readChartZoomMultiplier,
+  resetChartZoom,
+  zoomChart,
+  type ChartZoomDirection,
+} from '../charts/zoom';
 
 type ChartZoomControlsProps = {
   chartRef: RefObject<EChartsInstance | null>;
 };
 
 export function ChartZoomControls({ chartRef }: ChartZoomControlsProps) {
+  const [zoomMultiplier, setZoomMultiplier] = useState<number | null>(null);
+
+  useEffect(() => {
+    let animationFrame = 0;
+    let detachChartEvents: (() => void) | null = null;
+
+    const attachChartEvents = () => {
+      const chart = chartRef.current;
+      if (!chart) {
+        animationFrame = window.requestAnimationFrame(attachChartEvents);
+        return;
+      }
+
+      const updateZoomMultiplier = () => {
+        setZoomMultiplier(readChartZoomMultiplier(chart));
+      };
+
+      chart.on('datazoom', updateZoomMultiplier);
+      chart.on('finished', updateZoomMultiplier);
+      updateZoomMultiplier();
+
+      detachChartEvents = () => {
+        chart.off('datazoom', updateZoomMultiplier);
+        chart.off('finished', updateZoomMultiplier);
+      };
+    };
+
+    attachChartEvents();
+
+    return () => {
+      if (animationFrame) {
+        window.cancelAnimationFrame(animationFrame);
+      }
+
+      detachChartEvents?.();
+    };
+  }, [chartRef]);
+
   const handleZoom = (direction: ChartZoomDirection) => {
     const chart = chartRef.current;
     if (!chart) {
@@ -15,10 +58,31 @@ export function ChartZoomControls({ chartRef }: ChartZoomControlsProps) {
     }
 
     zoomChart(chart, direction);
+    setZoomMultiplier(readChartZoomMultiplier(chart));
+  };
+
+  const handleResetZoom = () => {
+    const chart = chartRef.current;
+    if (!chart) {
+      return;
+    }
+
+    resetChartZoom(chart);
+    setZoomMultiplier(null);
   };
 
   return (
     <div className="chart-zoom-controls" aria-label="Chart zoom controls">
+      {zoomMultiplier ? (
+        <button
+          aria-label="Reset zoom to 1X"
+          className="chart-zoom-controls__label"
+          onClick={handleResetZoom}
+          type="button"
+        >
+          {zoomMultiplier}X
+        </button>
+      ) : null}
       <button
         aria-label="Zoom in"
         className="chart-zoom-controls__button"

--- a/src/client/styles/charts.css
+++ b/src/client/styles/charts.css
@@ -23,6 +23,25 @@
   pointer-events: none;
 }
 
+.chart-zoom-controls__label {
+  justify-self: center;
+  min-width: 32px;
+  padding: 3px 6px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 8px;
+  background: var(--color-header-surface);
+  box-shadow: var(--shadow-button);
+  color: var(--color-muted);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.68rem;
+  font-weight: 800;
+  line-height: 1;
+  pointer-events: auto;
+  text-align: center;
+  touch-action: manipulation;
+}
+
 .chart-zoom-controls__button {
   display: inline-flex;
   width: 32px;
@@ -55,7 +74,9 @@
 }
 
 .chart-zoom-controls__button:hover,
-.chart-zoom-controls__button:focus-visible {
+.chart-zoom-controls__button:focus-visible,
+.chart-zoom-controls__label:hover,
+.chart-zoom-controls__label:focus-visible {
   border-color: var(--color-accent);
   background: var(--color-accent-soft);
   color: var(--color-accent-strong);


### PR DESCRIPTION
## Summary
- Cap zoom stepping at `8X` and update the shared zoom range logic accordingly
- Make the multiplier label act as a reset control that returns the chart to `1X` and hides itself
- Keep the chart `dataZoom` minimum span aligned with the new zoom cap

## Testing
- `npm run test -- src/client/charts/zoom.test.ts src/client/charts/options/options.test.ts`
- `npm run test`