### PR TITLE
Fix invalid start date handling on post creation

### DIFF
--- a/src/server/core/post-config.test.ts
+++ b/src/server/core/post-config.test.ts
@@ -4,6 +4,7 @@ import {
   createPostData,
   createPostForm,
   parseFormDateRange,
+  PostFormValidationError,
   readPostConfig,
   type CreatePostFormValues,
 } from './post-config';
@@ -21,6 +22,23 @@ test('parses selected day from midnight in the selected timezone', () => {
     startIso: '2026-01-01T15:00:00.000Z',
     endIso: '2026-01-02T15:00:00.000Z',
   });
+});
+
+test('rejects impossible selected start dates before date rollover', () => {
+  const invalidValues: CreatePostFormValues = {
+    ...formValues,
+    startMonth: ['2'],
+    startDay: ['30'],
+  };
+  const rolledDate = new Date(Date.UTC(2026, 1, 30));
+
+  expect(rolledDate.toISOString()).toBe('2026-03-02T00:00:00.000Z');
+  expect(() => parseFormDateRange(invalidValues)).toThrow(
+    PostFormValidationError
+  );
+  expect(() => parseFormDateRange(invalidValues)).toThrow(
+    'Select a valid start date. February 30, 2026 does not exist.'
+  );
 });
 
 test('create post form omits hour and prioritizes timezone options', () => {

--- a/src/server/core/post-config.ts
+++ b/src/server/core/post-config.ts
@@ -31,6 +31,17 @@ export type ValidatedPostConfig = {
   end: Date;
 };
 
+export class PostFormValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PostFormValidationError';
+  }
+}
+
+export const isPostFormValidationError = (
+  error: unknown
+): error is PostFormValidationError => error instanceof PostFormValidationError;
+
 type DateParts = {
   year: number;
   month: number;
@@ -72,7 +83,7 @@ export const createPostForm = (options: CreatePostFormOptions = {}): Form => {
       name: 'title',
       label: 'Title',
       placeholder: 'Subreddit Activity Charts',
-      defaultValue: normalizeTitle(defaultValues.title),
+      defaultValue: defaultValues.title ?? normalizeTitle(defaultValues.title),
     },
     {
       type: 'select',
@@ -138,7 +149,7 @@ export const createPostForm = (options: CreatePostFormOptions = {}): Form => {
       type: 'boolean',
       name: 'useTestDataSource',
       label: `Use r/${TEST_DATA_SOURCE_SUBREDDIT_NAME} as data source`,
-      defaultValue: false,
+      defaultValue: defaultValues.useTestDataSource === true,
     });
   }
 
@@ -259,7 +270,7 @@ export const resolveCurrentTimeZone = (
 };
 
 const createDateRangeFromParts = (parts: DateRangeParts): DateRange => {
-  validateDateParts(parts);
+  validateDateParts(parts, 'start date');
 
   const start = zonedDateTimeToUtc(parts);
   const endDate = addCalendarDays(parts, parts.durationDays);
@@ -348,7 +359,7 @@ const parseSelectNumber = (
     selectedNumber < min ||
     selectedNumber > max
   ) {
-    throw new Error(`Select a valid ${fieldLabel}.`);
+    throw new PostFormValidationError(`Select a valid ${fieldLabel}.`);
   }
 
   return selectedNumber;
@@ -358,7 +369,7 @@ const parseTimeZone = (value: SelectValue): string => {
   const timeZone = readSingleSelectValue(value, 'timezone');
 
   if (!isValidTimeZone(timeZone)) {
-    throw new Error('Select a valid timezone.');
+    throw new PostFormValidationError('Select a valid timezone.');
   }
 
   return timeZone;
@@ -373,7 +384,7 @@ const readSingleSelectValue = (
     typeof selectedValue === 'string' ? selectedValue.trim() : '';
 
   if (!normalized) {
-    throw new Error(`Select a ${fieldLabel}.`);
+    throw new PostFormValidationError(`Select a ${fieldLabel}.`);
   }
 
   return normalized;
@@ -398,9 +409,48 @@ const validateDateParts = (parts: DateParts, fieldName = 'date'): void => {
     date.getUTCMonth() !== parts.month - 1 ||
     date.getUTCDate() !== parts.day
   ) {
-    throw new Error(`Invalid ${fieldName}.`);
+    throw new PostFormValidationError(
+      createInvalidDateMessage(parts, fieldName)
+    );
   }
 };
+
+const createInvalidDateMessage = (
+  parts: DateParts,
+  fieldName: string
+): string => {
+  if (fieldName === 'start date' && canFormatDateParts(parts)) {
+    const formattedDate = `${formatMonthName(parts.month)} ${parts.day}, ${parts.year}`;
+    return `Select a valid start date. ${formattedDate} does not exist.`;
+  }
+
+  return `Select a valid ${fieldName}.`;
+};
+
+const canFormatDateParts = (parts: DateParts): boolean =>
+  Number.isInteger(parts.year) &&
+  Number.isInteger(parts.month) &&
+  Number.isInteger(parts.day) &&
+  parts.month >= 1 &&
+  parts.month <= monthNames.length;
+
+const monthNames = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+const formatMonthName = (month: number): string =>
+  monthNames[month - 1] ?? 'Month';
 
 const isValidTimeZone = (timeZone: string): boolean => {
   try {
@@ -440,7 +490,9 @@ const zonedDateTimeToUtc = (parts: ZonedDateParts): Date => {
     actualParts.day !== parts.day ||
     actualParts.hour !== defaultStartHour
   ) {
-    throw new Error('Selected start time does not exist in that timezone.');
+    throw new PostFormValidationError(
+      'Selected start time does not exist in that timezone.'
+    );
   }
 
   return date;

--- a/src/server/routes/forms.test.ts
+++ b/src/server/routes/forms.test.ts
@@ -1,0 +1,108 @@
+import { reddit } from '@devvit/web/server';
+import { expect, test, vi, beforeEach } from 'vitest';
+
+import type { CreatePostFormValues } from '../core/post-config';
+import { forms } from './forms';
+
+vi.mock('@devvit/web/server', () => ({
+  context: {
+    subredditName: 'bubblesneverlie_dev',
+  },
+  reddit: {
+    submitCustomPost: vi.fn(),
+  },
+}));
+
+const submittedValues: CreatePostFormValues = {
+  title: 'February report',
+  startYear: ['2026'],
+  startMonth: ['2'],
+  startDay: ['30'],
+  timeZone: ['UTC'],
+  durationDays: ['3'],
+  useTestDataSource: true,
+};
+
+beforeEach(() => {
+  vi.mocked(reddit.submitCustomPost).mockReset();
+});
+
+test('reopens create post form with submitted values when start date is invalid', async () => {
+  const response = await forms.request('/create-post-submit', {
+    method: 'POST',
+    body: JSON.stringify(submittedValues),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  const body: unknown = await response.json();
+  const fields = readFormFields(body);
+
+  expect(response.status).toBe(200);
+  expect(reddit.submitCustomPost).not.toHaveBeenCalled();
+  expect(body).toMatchObject({
+    showToast: 'Select a valid start date. February 30, 2026 does not exist.',
+    showForm: {
+      name: 'createPostForm',
+      data: submittedValues,
+    },
+  });
+  expect(fields).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: 'title',
+        defaultValue: 'February report',
+      }),
+      expect.objectContaining({
+        name: 'startYear',
+        defaultValue: ['2026'],
+      }),
+      expect.objectContaining({
+        name: 'startMonth',
+        defaultValue: ['2'],
+      }),
+      expect.objectContaining({
+        name: 'startDay',
+        defaultValue: ['30'],
+      }),
+      expect.objectContaining({
+        name: 'timeZone',
+        defaultValue: ['UTC'],
+      }),
+      expect.objectContaining({
+        name: 'durationDays',
+        defaultValue: ['3'],
+      }),
+      expect.objectContaining({
+        name: 'useTestDataSource',
+        defaultValue: true,
+      }),
+    ])
+  );
+});
+
+const readFormFields = (body: unknown): unknown[] => {
+  if (!isRecord(body)) {
+    throw new Error('Expected response body.');
+  }
+
+  const showForm = body.showForm;
+  if (!isRecord(showForm)) {
+    throw new Error('Expected showForm response.');
+  }
+
+  const form = showForm.form;
+  if (!isRecord(form)) {
+    throw new Error('Expected form response.');
+  }
+
+  const fields = form.fields;
+  if (!Array.isArray(fields)) {
+    throw new Error('Expected form fields.');
+  }
+
+  return fields;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);

--- a/src/server/routes/forms.ts
+++ b/src/server/routes/forms.ts
@@ -1,15 +1,24 @@
 import { Hono } from 'hono';
-import type { UiResponse } from '@devvit/web/shared';
+import { context } from '@devvit/web/server';
+import type { JsonObject, UiResponse } from '@devvit/web/shared';
 import { createPost } from '../core/post';
-import type { CreatePostFormValues } from '../core/post-config';
+import {
+  createPostForm,
+  isPostFormValidationError,
+  resolveCurrentTimeZone,
+  type CreatePostFormValues,
+} from '../core/post-config';
+import { canUseTestDataSource } from '../core/subreddits';
 import { createLogger } from '../logging/logger';
 
 export const forms = new Hono();
 const logger = createLogger('forms:create-post');
 
 forms.post('/create-post-submit', async (c) => {
+  let values: CreatePostFormValues | undefined;
+
   try {
-    const values = await c.req.json<CreatePostFormValues>();
+    values = await c.req.json<CreatePostFormValues>();
     logger.info(
       'Received create post form submission',
       createFormLogMetadata(values)
@@ -30,6 +39,32 @@ forms.post('/create-post-submit', async (c) => {
   } catch (error) {
     const message =
       error instanceof Error ? error.message : 'Failed to create post.';
+
+    if (values && isPostFormValidationError(error)) {
+      logger.warn('Create Bubbles Never Lie post validation failed', {
+        ...createFormLogMetadata(values),
+        error: message,
+      });
+
+      return c.json<UiResponse>(
+        {
+          showToast: message,
+          showForm: {
+            name: 'createPostForm',
+            form: createPostForm({
+              allowTestDataSource: canUseTestDataSource(context.subredditName),
+              currentTimeZone: resolveCurrentTimeZone(
+                readSingleFormValue(values.timeZone)
+              ),
+              defaultValues: values,
+            }),
+            data: createFormData(values),
+          },
+        },
+        200
+      );
+    }
+
     logger.error('Create Bubbles Never Lie post failed', { error: message });
 
     return c.json<UiResponse>(
@@ -54,6 +89,40 @@ const createFormLogMetadata = (values: unknown): Record<string, unknown> => {
     durationDays: data.durationDays,
     timeZone: data.timeZone,
   };
+};
+
+const createFormData = (values: CreatePostFormValues): JsonObject => {
+  const data: JsonObject = {};
+
+  copyFormValue(data, 'title', values.title);
+  copyFormValue(data, 'startYear', values.startYear);
+  copyFormValue(data, 'startMonth', values.startMonth);
+  copyFormValue(data, 'startDay', values.startDay);
+  copyFormValue(data, 'timeZone', values.timeZone);
+  copyFormValue(data, 'durationDays', values.durationDays);
+
+  if (values.useTestDataSource !== undefined) {
+    data.useTestDataSource = values.useTestDataSource;
+  }
+
+  return data;
+};
+
+const copyFormValue = (
+  data: JsonObject,
+  key: string,
+  value: string | string[] | undefined
+): void => {
+  if (value !== undefined) {
+    data[key] = value;
+  }
+};
+
+const readSingleFormValue = (
+  value: string | string[] | undefined
+): string | undefined => {
+  const selectedValue = Array.isArray(value) ? value[0] : value;
+  return typeof selectedValue === 'string' ? selectedValue : undefined;
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>


### PR DESCRIPTION
## Summary
- Treat impossible start dates like February 30 as form validation errors instead of letting post creation fail silently.
- Reopen the create-post form on validation failure with the submitted values preserved.
- Add regression coverage for date rollover handling and the form retry response.

## Testing
- `npm run test -- post-config forms`
- `npm run type-check`
- `npm run lint`