### PR TITLE
Add event-driven Redis cache refresh triggers

### DIFF
--- a/devvit.json
+++ b/devvit.json
@@ -44,6 +44,30 @@
     "onPostCreate": "/internal/triggers/on-post-create",
     "onCommentCreate": "/internal/triggers/on-comment-create"
   },
+  "scheduler": {
+    "tasks": {
+      "refreshPostCache": {
+        "endpoint": "/internal/cache/refresh-post-cache",
+        "cron": "* * * * *"
+      },
+      "refreshCommentCache": {
+        "endpoint": "/internal/cache/refresh-comment-cache",
+        "cron": "0 * * * *"
+      },
+      "refreshCommentCacheQueue": {
+        "endpoint": "/internal/cache/refresh-comment-cache-queue",
+        "cron": "* * * * *"
+      },
+      "refreshContributorCache": {
+        "endpoint": "/internal/cache/refresh-contributor-cache",
+        "cron": "*/30 * * * *"
+      },
+      "refreshSubredditIcons": {
+        "endpoint": "/internal/cache/refresh-subreddit-icons",
+        "cron": "0 * * * *"
+      }
+    }
+  },
   "scripts": {
     "dev": "vite build --watch",
     "build": "vite build"

--- a/devvit.json
+++ b/devvit.json
@@ -40,31 +40,9 @@
     "createPostForm": "/internal/form/create-post-submit"
   },
   "triggers": {
-    "onAppInstall": "/internal/triggers/on-app-install"
-  },
-  "scheduler": {
-    "tasks": {
-      "refreshPostCache": {
-        "endpoint": "/internal/cache/refresh-post-cache",
-        "cron": "* * * * *"
-      },
-      "refreshCommentCache": {
-        "endpoint": "/internal/cache/refresh-comment-cache",
-        "cron": "0 * * * *"
-      },
-      "refreshCommentCacheQueue": {
-        "endpoint": "/internal/cache/refresh-comment-cache-queue",
-        "cron": "* * * * *"
-      },
-      "refreshContributorCache": {
-        "endpoint": "/internal/cache/refresh-contributor-cache",
-        "cron": "*/30 * * * *"
-      },
-      "refreshSubredditIcons": {
-        "endpoint": "/internal/cache/refresh-subreddit-icons",
-        "cron": "0 * * * *"
-      }
-    }
+    "onAppInstall": "/internal/triggers/on-app-install",
+    "onPostCreate": "/internal/triggers/on-post-create",
+    "onCommentCreate": "/internal/triggers/on-comment-create"
   },
   "scripts": {
     "dev": "vite build --watch",

--- a/src/server/core/comment-cache.ts
+++ b/src/server/core/comment-cache.ts
@@ -503,13 +503,15 @@ const toChartComment = (comment: CommentWithAuthor): ChartComment => ({
 });
 
 const createCommentBodyPreview = (body: string): CommentBodyPreview => {
+  return {
+    bodyPreview: createCommentBodyPreviewText(body),
+  };
+};
+
+export const createCommentBodyPreviewText = (body: string): string => {
   const normalized = normalizeCommentBody(body);
 
-  return {
-    bodyPreview: truncateCommentPreview(
-      replaceFirstMediaPreviewToken(normalized)
-    ),
-  };
+  return truncateCommentPreview(replaceFirstMediaPreviewToken(normalized));
 };
 
 const truncateCommentPreview = (normalized: string): string => {

--- a/src/server/core/contributor-cache.ts
+++ b/src/server/core/contributor-cache.ts
@@ -18,6 +18,11 @@ export type ContributorCacheRefreshResult = {
   generatedAt: string;
 };
 
+export type ContributorMetadataRefreshResult = {
+  refreshedContributorCount: number;
+  generatedAt: string;
+};
+
 export const refreshContributorCache = async (
   subredditName: string
 ): Promise<ContributorCacheRefreshResult> => {
@@ -82,6 +87,58 @@ export const refreshContributorCache = async (
     });
     throw error;
   }
+};
+
+export const refreshContributorMetadata = async (
+  subredditName: string,
+  username: string
+): Promise<ContributorMetadataRefreshResult> => {
+  const contributorName = readRefreshableContributorName(username);
+  const fetchedAt = new Date();
+  const generatedAt = fetchedAt.toISOString();
+
+  if (!contributorName) {
+    logger.info('Skipped contributor metadata refresh', {
+      subredditName,
+      username,
+      generatedAt,
+    });
+
+    return {
+      refreshedContributorCount: 0,
+      generatedAt,
+    };
+  }
+
+  const dataLayer = createDataLayer(subredditName);
+  const contributor = await getContributorEntity(
+    contributorName,
+    fetchedAt,
+    shouldUseSyntheticContributorKarma(subredditName)
+  );
+
+  await dataLayer.contributors.upsert(contributor);
+
+  logger.info('Stored contributor metadata cache entry', {
+    subredditName,
+    username: contributorName,
+    generatedAt,
+  });
+
+  return {
+    refreshedContributorCount: 1,
+    generatedAt,
+  };
+};
+
+export const readRefreshableContributorName = (
+  username: string
+): string | null => {
+  const trimmed = username.trim();
+
+  return trimmed === '' || trimmed.toLowerCase() === '[deleted]'
+    ? null
+    : trimmed;
 };
 
 const getContributorEntity = async (
@@ -151,8 +208,8 @@ const getUniqueRefreshableContributorNames = (
         ...posts.map((post) => post.authorName),
         ...comments.map((comment) => comment.authorName),
       ]
-        .map((username) => username.trim())
-        .filter((username) => username !== '' && username !== '[deleted]')
+        .map(readRefreshableContributorName)
+        .filter((username): username is string => username !== null)
     )
   );
 

--- a/src/server/core/event-cache.test.ts
+++ b/src/server/core/event-cache.test.ts
@@ -115,13 +115,14 @@ type ContributorRefreshCall = {
   username: string;
 };
 
+type UsernameResolutionCall = {
+  authorId: string;
+};
+
 test('post create events write posts and refresh the post author contributor', async () => {
   const redisClient = new FakeRedisDataClient();
   const contributorRefreshCalls: ContributorRefreshCall[] = [];
-  const dependencies = createDependencies(
-    redisClient,
-    contributorRefreshCalls
-  );
+  const dependencies = createDependencies(redisClient, contributorRefreshCalls);
   const createdAt = Date.parse('2026-04-15T10:00:00.000Z') / 1000;
 
   const result = await cachePostCreateEvent(
@@ -165,14 +166,88 @@ test('post create events write posts and refresh the post author contributor', a
   ]);
 });
 
+test('event author account ids are resolved before caching contributors', async () => {
+  const redisClient = new FakeRedisDataClient();
+  const contributorRefreshCalls: ContributorRefreshCall[] = [];
+  const usernameResolutionCalls: UsernameResolutionCall[] = [];
+  const dependencies = createDependencies(
+    redisClient,
+    contributorRefreshCalls,
+    usernameResolutionCalls,
+    new Map([
+      ['t2_aliceid', 'alice'],
+      ['t2_bobid', 'bob'],
+    ])
+  );
+
+  await cachePostCreateEvent(
+    createPostCreateRequest({
+      post: createEventPost({
+        id: 'post_by_id',
+        authorId: 't2_aliceid',
+      }),
+      author: createEventUser({
+        id: 't2_aliceid',
+        name: 't2_aliceid',
+      }),
+    }),
+    dependencies
+  );
+  await cacheCommentCreateEvent(
+    createCommentCreateRequest({
+      comment: createEventComment({
+        id: 'comment_by_id',
+        author: 't2_bobid',
+      }),
+      author: createEventUser({
+        id: 't2_bobid',
+        name: 't2_bobid',
+      }),
+    }),
+    dependencies
+  );
+
+  const dataLayer = createDataLayer('examplesub', redisClient);
+
+  assert.deepEqual(await dataLayer.posts.getById('t3_post_by_id'), {
+    id: 't3_post_by_id',
+    title: 'Post title',
+    authorName: 'alice',
+    comments: 1,
+    score: 10,
+    createdAt: '2026-04-15T09:00:00.000Z',
+    permalink: '/r/ExampleSub/comments/post_1/post_title/',
+  });
+  assert.deepEqual(await dataLayer.comments.getById('t1_comment_by_id'), {
+    id: 't1_comment_by_id',
+    postId: 't3_post_1',
+    authorName: 'bob',
+    score: 5,
+    bodyPreview: 'Comment body',
+    createdAt: '2026-04-15T10:00:00.000Z',
+    permalink: '/r/ExampleSub/comments/post_1/comment_1/',
+  });
+  assert.deepEqual(contributorRefreshCalls, [
+    {
+      subredditName: 'examplesub',
+      username: 'alice',
+    },
+    {
+      subredditName: 'examplesub',
+      username: 'bob',
+    },
+  ]);
+  assert.deepEqual(usernameResolutionCalls, [
+    { authorId: 't2_aliceid' },
+    { authorId: 't2_bobid' },
+  ]);
+});
+
 test('comment create events write comments and update cached parent post counts', async () => {
   const redisClient = new FakeRedisDataClient();
   const dataLayer = createDataLayer('examplesub', redisClient);
   const contributorRefreshCalls: ContributorRefreshCall[] = [];
-  const dependencies = createDependencies(
-    redisClient,
-    contributorRefreshCalls
-  );
+  const dependencies = createDependencies(redisClient, contributorRefreshCalls);
 
   await dataLayer.posts.upsert({
     id: 't3_post_1',
@@ -245,10 +320,7 @@ test('comment create events write comments and update cached parent post counts'
 test('missing post or comment payloads are no-op successes', async () => {
   const redisClient = new FakeRedisDataClient();
   const contributorRefreshCalls: ContributorRefreshCall[] = [];
-  const dependencies = createDependencies(
-    redisClient,
-    contributorRefreshCalls
-  );
+  const dependencies = createDependencies(redisClient, contributorRefreshCalls);
 
   const postResult = await cachePostCreateEvent(
     {
@@ -294,10 +366,7 @@ test('missing post or comment payloads are no-op successes', async () => {
 test('deleted authors are cached without contributor metadata refresh', async () => {
   const redisClient = new FakeRedisDataClient();
   const contributorRefreshCalls: ContributorRefreshCall[] = [];
-  const dependencies = createDependencies(
-    redisClient,
-    contributorRefreshCalls
-  );
+  const dependencies = createDependencies(redisClient, contributorRefreshCalls);
 
   const result = await cacheCommentCreateEvent(
     createCommentCreateRequest({
@@ -316,13 +385,19 @@ test('deleted authors are cached without contributor metadata refresh', async ()
 
 const createDependencies = (
   redisClient: RedisDataClient,
-  contributorRefreshCalls: ContributorRefreshCall[]
+  contributorRefreshCalls: ContributorRefreshCall[],
+  usernameResolutionCalls: UsernameResolutionCall[] = [],
+  usernamesById: Map<string, string> = new Map()
 ): EventCacheDependencies => ({
   createDataLayerForSubreddit: (subredditName) =>
     createDataLayer(subredditName, redisClient),
   refreshContributor: async (options) => {
     contributorRefreshCalls.push(options);
     return 1;
+  },
+  resolveUsernameById: async (authorId) => {
+    usernameResolutionCalls.push({ authorId });
+    return usernamesById.get(authorId) ?? null;
   },
   currentSubredditName: 'FallbackSub',
   now: () => new Date('2026-04-15T12:00:00.000Z'),
@@ -407,9 +482,7 @@ const createEventPost = (overrides: Partial<PostV2> = {}): PostV2 => ({
   ...overrides,
 });
 
-const createEventComment = (
-  overrides: Partial<CommentV2> = {}
-): CommentV2 => ({
+const createEventComment = (overrides: Partial<CommentV2> = {}): CommentV2 => ({
   id: 'comment_1',
   parentId: 't3_post_1',
   body: 'Comment body',

--- a/src/server/core/event-cache.test.ts
+++ b/src/server/core/event-cache.test.ts
@@ -1,0 +1,468 @@
+import assert from 'node:assert/strict';
+import {
+  CrowdControlLevel,
+  DistinguishType,
+  SubredditRating,
+  SubredditType,
+  type CommentV2,
+  type OnCommentCreateRequest,
+  type OnPostCreateRequest,
+  type PostV2,
+  type SubredditV2,
+  type UserV2,
+} from '@devvit/web/shared';
+import { test } from 'vitest';
+import { createDataLayer, type RedisDataClient } from '../data';
+import {
+  cacheCommentCreateEvent,
+  cachePostCreateEvent,
+  type EventCacheDependencies,
+} from './event-cache';
+
+class FakeRedisDataClient implements RedisDataClient {
+  readonly hashes = new Map<string, Map<string, string>>();
+  readonly sortedSets = new Map<string, Map<string, number>>();
+
+  async hGet(key: string, field: string): Promise<string | undefined> {
+    return this.hashes.get(key)?.get(field);
+  }
+
+  async hMGet(key: string, fields: string[]): Promise<(string | null)[]> {
+    const hash = this.hashes.get(key);
+
+    return fields.map((field) => hash?.get(field) ?? null);
+  }
+
+  async hSet(
+    key: string,
+    fieldValues: { [field: string]: string }
+  ): Promise<number> {
+    const hash = this.hashes.get(key) ?? new Map<string, string>();
+    let addedFieldCount = 0;
+
+    Object.entries(fieldValues).forEach(([field, value]) => {
+      if (!hash.has(field)) {
+        addedFieldCount += 1;
+      }
+
+      hash.set(field, value);
+    });
+
+    this.hashes.set(key, hash);
+    return addedFieldCount;
+  }
+
+  async zAdd(
+    key: string,
+    ...members: Array<{ member: string; score: number }>
+  ): Promise<number> {
+    const sortedSet = this.sortedSets.get(key) ?? new Map<string, number>();
+    let addedMemberCount = 0;
+
+    members.forEach(({ member, score }) => {
+      if (!sortedSet.has(member)) {
+        addedMemberCount += 1;
+      }
+
+      sortedSet.set(member, score);
+    });
+
+    this.sortedSets.set(key, sortedSet);
+    return addedMemberCount;
+  }
+
+  async zRange(
+    key: string,
+    start: number | string,
+    stop: number | string,
+    options?: Parameters<RedisDataClient['zRange']>[3]
+  ): Promise<Array<{ member: string; score: number }>> {
+    const indexedEntities = [...(this.sortedSets.get(key)?.entries() ?? [])]
+      .map(([member, score]) => ({ member, score }))
+      .sort((a, b) => a.score - b.score || a.member.localeCompare(b.member));
+
+    if (options?.by === 'rank') {
+      const rankedEntities = options.reverse
+        ? indexedEntities.toReversed()
+        : indexedEntities;
+      const startRank = Number(start);
+      const stopRank = Number(stop);
+      const endRank =
+        stopRank < 0 ? rankedEntities.length + stopRank : stopRank;
+
+      return rankedEntities.slice(startRank, endRank + 1);
+    }
+
+    const startScore = Number(start);
+    const stopScore = Number(stop);
+    const matchedEntities = indexedEntities.filter(
+      ({ score }) => score >= startScore && score <= stopScore
+    );
+
+    if (options?.limit) {
+      return matchedEntities.slice(
+        options.limit.offset,
+        options.limit.offset + options.limit.count
+      );
+    }
+
+    return matchedEntities;
+  }
+}
+
+type ContributorRefreshCall = {
+  subredditName: string;
+  username: string;
+};
+
+test('post create events write posts and refresh the post author contributor', async () => {
+  const redisClient = new FakeRedisDataClient();
+  const contributorRefreshCalls: ContributorRefreshCall[] = [];
+  const dependencies = createDependencies(
+    redisClient,
+    contributorRefreshCalls
+  );
+  const createdAt = Date.parse('2026-04-15T10:00:00.000Z') / 1000;
+
+  const result = await cachePostCreateEvent(
+    createPostCreateRequest({
+      post: createEventPost({
+        id: 'post_1',
+        title: 'Fresh post',
+        createdAt,
+        score: 42,
+        numComments: 7,
+        permalink: '/r/ExampleSub/comments/post_1/fresh_post/',
+      }),
+      author: createEventUser({ name: 'alice' }),
+    }),
+    dependencies
+  );
+  const dataLayer = createDataLayer('examplesub', redisClient);
+
+  assert.deepEqual(result, {
+    status: 'cached',
+    subredditName: 'examplesub',
+    cachedPostCount: 1,
+    cachedCommentCount: 0,
+    refreshedContributorCount: 1,
+    generatedAt: '2026-04-15T12:00:00.000Z',
+  });
+  assert.deepEqual(await dataLayer.posts.getById('t3_post_1'), {
+    id: 't3_post_1',
+    title: 'Fresh post',
+    authorName: 'alice',
+    comments: 7,
+    score: 42,
+    createdAt: '2026-04-15T10:00:00.000Z',
+    permalink: '/r/ExampleSub/comments/post_1/fresh_post/',
+  });
+  assert.deepEqual(contributorRefreshCalls, [
+    {
+      subredditName: 'examplesub',
+      username: 'alice',
+    },
+  ]);
+});
+
+test('comment create events write comments and update cached parent post counts', async () => {
+  const redisClient = new FakeRedisDataClient();
+  const dataLayer = createDataLayer('examplesub', redisClient);
+  const contributorRefreshCalls: ContributorRefreshCall[] = [];
+  const dependencies = createDependencies(
+    redisClient,
+    contributorRefreshCalls
+  );
+
+  await dataLayer.posts.upsert({
+    id: 't3_post_1',
+    title: 'Original post',
+    authorName: 'post-author',
+    comments: 1,
+    score: 10,
+    createdAt: '2026-04-15T09:00:00.000Z',
+    permalink: '/r/ExampleSub/comments/post_1/original_post/',
+  });
+
+  const result = await cacheCommentCreateEvent(
+    createCommentCreateRequest({
+      comment: createEventComment({
+        id: 'comment_1',
+        postId: 'post_1',
+        author: 'bob',
+        body: 'A new comment',
+        createdAt: Date.parse('2026-04-15T10:05:00.000Z'),
+        score: 5,
+        permalink: '/r/ExampleSub/comments/post_1/comment_1/',
+      }),
+      post: createEventPost({
+        id: 'post_1',
+        title: 'Updated post',
+        numComments: 2,
+        score: 11,
+        createdAt: Date.parse('2026-04-15T09:00:00.000Z'),
+        permalink: '/r/ExampleSub/comments/post_1/updated_post/',
+      }),
+      author: createEventUser({ name: 'bob' }),
+    }),
+    dependencies
+  );
+
+  assert.deepEqual(result, {
+    status: 'cached',
+    subredditName: 'examplesub',
+    cachedPostCount: 1,
+    cachedCommentCount: 1,
+    refreshedContributorCount: 1,
+    generatedAt: '2026-04-15T12:00:00.000Z',
+  });
+  assert.deepEqual(await dataLayer.comments.getById('t1_comment_1'), {
+    id: 't1_comment_1',
+    postId: 't3_post_1',
+    authorName: 'bob',
+    score: 5,
+    bodyPreview: 'A new comment',
+    createdAt: '2026-04-15T10:05:00.000Z',
+    permalink: '/r/ExampleSub/comments/post_1/comment_1/',
+  });
+  assert.deepEqual(await dataLayer.posts.getById('t3_post_1'), {
+    id: 't3_post_1',
+    title: 'Updated post',
+    authorName: 'post-author',
+    comments: 2,
+    score: 11,
+    createdAt: '2026-04-15T09:00:00.000Z',
+    permalink: '/r/ExampleSub/comments/post_1/updated_post/',
+  });
+  assert.deepEqual(contributorRefreshCalls, [
+    {
+      subredditName: 'examplesub',
+      username: 'bob',
+    },
+  ]);
+});
+
+test('missing post or comment payloads are no-op successes', async () => {
+  const redisClient = new FakeRedisDataClient();
+  const contributorRefreshCalls: ContributorRefreshCall[] = [];
+  const dependencies = createDependencies(
+    redisClient,
+    contributorRefreshCalls
+  );
+
+  const postResult = await cachePostCreateEvent(
+    {
+      type: 'PostCreate',
+      author: createEventUser(),
+      subreddit: createEventSubreddit(),
+    },
+    dependencies
+  );
+  const commentResult = await cacheCommentCreateEvent(
+    {
+      type: 'CommentCreate',
+      post: createEventPost(),
+      author: createEventUser(),
+      subreddit: createEventSubreddit(),
+    },
+    dependencies
+  );
+
+  assert.deepEqual(postResult, {
+    status: 'skipped',
+    subredditName: 'examplesub',
+    cachedPostCount: 0,
+    cachedCommentCount: 0,
+    refreshedContributorCount: 0,
+    generatedAt: '2026-04-15T12:00:00.000Z',
+    skippedReason: 'missing_or_invalid_post_payload',
+  });
+  assert.deepEqual(commentResult, {
+    status: 'skipped',
+    subredditName: 'examplesub',
+    cachedPostCount: 0,
+    cachedCommentCount: 0,
+    refreshedContributorCount: 0,
+    generatedAt: '2026-04-15T12:00:00.000Z',
+    skippedReason: 'missing_or_invalid_comment_payload',
+  });
+  assert.equal(redisClient.hashes.size, 0);
+  assert.equal(redisClient.sortedSets.size, 0);
+  assert.deepEqual(contributorRefreshCalls, []);
+});
+
+test('deleted authors are cached without contributor metadata refresh', async () => {
+  const redisClient = new FakeRedisDataClient();
+  const contributorRefreshCalls: ContributorRefreshCall[] = [];
+  const dependencies = createDependencies(
+    redisClient,
+    contributorRefreshCalls
+  );
+
+  const result = await cacheCommentCreateEvent(
+    createCommentCreateRequest({
+      comment: createEventComment({
+        author: '[deleted]',
+      }),
+      author: createEventUser({ name: '[deleted]' }),
+    }),
+    dependencies
+  );
+
+  assert.equal(result.status, 'cached');
+  assert.equal(result.refreshedContributorCount, 0);
+  assert.deepEqual(contributorRefreshCalls, []);
+});
+
+const createDependencies = (
+  redisClient: RedisDataClient,
+  contributorRefreshCalls: ContributorRefreshCall[]
+): EventCacheDependencies => ({
+  createDataLayerForSubreddit: (subredditName) =>
+    createDataLayer(subredditName, redisClient),
+  refreshContributor: async (options) => {
+    contributorRefreshCalls.push(options);
+    return 1;
+  },
+  currentSubredditName: 'FallbackSub',
+  now: () => new Date('2026-04-15T12:00:00.000Z'),
+});
+
+const createPostCreateRequest = ({
+  post = createEventPost(),
+  author = createEventUser(),
+  subreddit = createEventSubreddit(),
+}: {
+  post?: PostV2 | undefined;
+  author?: UserV2 | undefined;
+  subreddit?: SubredditV2 | undefined;
+} = {}): OnPostCreateRequest => ({
+  type: 'PostCreate',
+  post,
+  author,
+  subreddit,
+});
+
+const createCommentCreateRequest = ({
+  comment = createEventComment(),
+  post = createEventPost(),
+  author = createEventUser({ name: 'commenter' }),
+  subreddit = createEventSubreddit(),
+}: {
+  comment?: CommentV2 | undefined;
+  post?: PostV2 | undefined;
+  author?: UserV2 | undefined;
+  subreddit?: SubredditV2 | undefined;
+} = {}): OnCommentCreateRequest => ({
+  type: 'CommentCreate',
+  comment,
+  post,
+  author,
+  subreddit,
+});
+
+const createEventPost = (overrides: Partial<PostV2> = {}): PostV2 => ({
+  id: 'post_1',
+  title: 'Post title',
+  selftext: '',
+  nsfw: false,
+  authorId: 't2_post_author',
+  crowdControlLevel: CrowdControlLevel.OFF,
+  numReports: 0,
+  isGallery: false,
+  isMeta: false,
+  createdAt: Date.parse('2026-04-15T09:00:00.000Z') / 1000,
+  isApproved: true,
+  isArchived: false,
+  distinguished: DistinguishType.NULL_VALUE,
+  ignoreReports: false,
+  isSelf: true,
+  isVideo: false,
+  isLocked: false,
+  isSpoiler: false,
+  subredditId: 't5_examplesub',
+  upvotes: 12,
+  downvotes: 2,
+  url: 'https://www.reddit.com/r/ExampleSub/comments/post_1/post_title/',
+  isSticky: false,
+  spam: false,
+  deleted: false,
+  languageCode: 'en',
+  updatedAt: 0,
+  gildings: 0,
+  score: 10,
+  numComments: 1,
+  thumbnail: '',
+  crosspostParentId: '',
+  permalink: '/r/ExampleSub/comments/post_1/post_title/',
+  isPoll: false,
+  isPromoted: false,
+  isMultiMedia: false,
+  type: 'text',
+  unlisted: false,
+  galleryImages: [],
+  isImage: false,
+  mediaUrls: [],
+  isClubContent: false,
+  ...overrides,
+});
+
+const createEventComment = (
+  overrides: Partial<CommentV2> = {}
+): CommentV2 => ({
+  id: 'comment_1',
+  parentId: 't3_post_1',
+  body: 'Comment body',
+  author: 'commenter',
+  numReports: 0,
+  collapsedBecauseCrowdControl: false,
+  spam: false,
+  deleted: false,
+  createdAt: Date.parse('2026-04-15T10:00:00.000Z') / 1000,
+  upvotes: 6,
+  downvotes: 1,
+  languageCode: 'en',
+  lastModifiedAt: 0,
+  gilded: false,
+  score: 5,
+  permalink: '/r/ExampleSub/comments/post_1/comment_1/',
+  hasMedia: false,
+  postId: 'post_1',
+  subredditId: 't5_examplesub',
+  elementTypes: [],
+  mediaUrls: [],
+  ...overrides,
+});
+
+const createEventUser = (overrides: Partial<UserV2> = {}): UserV2 => ({
+  id: 't2_user',
+  name: 'alice',
+  isGold: false,
+  snoovatarImage: '',
+  url: '/user/alice/',
+  spam: false,
+  banned: false,
+  karma: 100,
+  iconImage: '',
+  description: '',
+  suspended: false,
+  ...overrides,
+});
+
+const createEventSubreddit = (
+  overrides: Partial<SubredditV2> = {}
+): SubredditV2 => ({
+  id: 't5_examplesub',
+  name: 'ExampleSub',
+  nsfw: false,
+  type: SubredditType.PUBLIC,
+  spam: false,
+  quarantined: false,
+  topics: [],
+  rating: SubredditRating.E,
+  subscribersCount: 1000,
+  permalink: '/r/ExampleSub/',
+  title: 'ExampleSub',
+  description: '',
+  ...overrides,
+});

--- a/src/server/core/event-cache.ts
+++ b/src/server/core/event-cache.ts
@@ -1,0 +1,362 @@
+import { context } from '@devvit/web/server';
+import type {
+  CommentV2,
+  OnCommentCreateRequest,
+  OnPostCreateRequest,
+  PostV2,
+  SubredditV2,
+  UserV2,
+} from '@devvit/web/shared';
+import { createDataLayer, type DataLayer } from '../data';
+import type { CommentEntity, PostEntity } from '../data';
+import { createLogger } from '../logging/logger';
+import {
+  readRefreshableContributorName,
+  refreshContributorMetadata,
+} from './contributor-cache';
+import { createCommentBodyPreviewText } from './comment-cache';
+import { normalizeSubredditName } from './subreddits';
+
+const logger = createLogger('event-cache');
+const SECONDS_TIMESTAMP_THRESHOLD = 10_000_000_000;
+
+type EventDataLayer = Pick<DataLayer, 'posts' | 'comments'>;
+
+type EventContributorRefreshOptions = {
+  subredditName: string;
+  username: string;
+};
+
+type EventContributorRefresh = (
+  options: EventContributorRefreshOptions
+) => Promise<number>;
+
+export type EventCacheDependencies = {
+  createDataLayerForSubreddit?: (subredditName: string) => EventDataLayer;
+  refreshContributor?: EventContributorRefresh;
+  currentSubredditName?: string;
+  now?: () => Date;
+};
+
+export type EventCacheResult = {
+  status: 'cached' | 'skipped';
+  subredditName: string;
+  cachedPostCount: number;
+  cachedCommentCount: number;
+  refreshedContributorCount: number;
+  generatedAt: string;
+  skippedReason?: string;
+};
+
+export const cachePostCreateEvent = async (
+  input: OnPostCreateRequest,
+  {
+    createDataLayerForSubreddit = createDataLayer,
+    refreshContributor = refreshEventContributor,
+    currentSubredditName = context.subredditName,
+    now = () => new Date(),
+  }: EventCacheDependencies = {}
+): Promise<EventCacheResult> => {
+  const subredditName = resolveEventSubredditName(
+    input.subreddit,
+    currentSubredditName
+  );
+  const post = createPostEntityFromEvent(input.post, input.author);
+
+  if (!post) {
+    return createSkippedEventCacheResult({
+      subredditName,
+      skippedReason: 'missing_or_invalid_post_payload',
+      now,
+    });
+  }
+
+  const dataLayer = createDataLayerForSubreddit(subredditName);
+
+  await dataLayer.posts.upsert(post);
+
+  const refreshedContributorCount = await refreshContributorForAuthor({
+    subredditName,
+    authorName: post.authorName,
+    refreshContributor,
+  });
+
+  return {
+    status: 'cached',
+    subredditName,
+    cachedPostCount: 1,
+    cachedCommentCount: 0,
+    refreshedContributorCount,
+    generatedAt: now().toISOString(),
+  };
+};
+
+export const cacheCommentCreateEvent = async (
+  input: OnCommentCreateRequest,
+  {
+    createDataLayerForSubreddit = createDataLayer,
+    refreshContributor = refreshEventContributor,
+    currentSubredditName = context.subredditName,
+    now = () => new Date(),
+  }: EventCacheDependencies = {}
+): Promise<EventCacheResult> => {
+  const subredditName = resolveEventSubredditName(
+    input.subreddit,
+    currentSubredditName
+  );
+  const comment = createCommentEntityFromEvent(
+    input.comment,
+    input.post,
+    input.author
+  );
+
+  if (!comment) {
+    return createSkippedEventCacheResult({
+      subredditName,
+      skippedReason: 'missing_or_invalid_comment_payload',
+      now,
+    });
+  }
+
+  const dataLayer = createDataLayerForSubreddit(subredditName);
+  const [parentPostCached] = await Promise.all([
+    upsertExistingParentPostFromEvent(input.post, dataLayer),
+    dataLayer.comments.upsert(comment),
+  ]);
+  const refreshedContributorCount = await refreshContributorForAuthor({
+    subredditName,
+    authorName: comment.authorName,
+    refreshContributor,
+  });
+
+  return {
+    status: 'cached',
+    subredditName,
+    cachedPostCount: parentPostCached ? 1 : 0,
+    cachedCommentCount: 1,
+    refreshedContributorCount,
+    generatedAt: now().toISOString(),
+  };
+};
+
+const refreshEventContributor: EventContributorRefresh = async ({
+  subredditName,
+  username,
+}) => {
+  const result = await refreshContributorMetadata(subredditName, username);
+
+  return result.refreshedContributorCount;
+};
+
+const refreshContributorForAuthor = async ({
+  subredditName,
+  authorName,
+  refreshContributor,
+}: {
+  subredditName: string;
+  authorName: string;
+  refreshContributor: EventContributorRefresh;
+}): Promise<number> => {
+  const username = readRefreshableContributorName(authorName);
+
+  if (!username) {
+    return 0;
+  }
+
+  try {
+    return await refreshContributor({ subredditName, username });
+  } catch (error) {
+    logger.warn('Contributor metadata refresh failed after event cache write', {
+      subredditName,
+      username,
+      error: getErrorMessage(error),
+    });
+
+    return 0;
+  }
+};
+
+const createPostEntityFromEvent = (
+  post: PostV2 | undefined,
+  author: UserV2 | undefined
+): PostEntity | null => {
+  if (!post) {
+    return null;
+  }
+
+  const id = normalizeThingId(post.id, 't3_');
+  const title = readRequiredText(post.title);
+  const authorName = readRequiredText(author?.name);
+  const createdAt = readEventCreatedAt(post.createdAt);
+  const permalink = readRequiredText(post.permalink);
+  const comments = readFiniteNumber(post.numComments);
+  const score = readFiniteNumber(post.score);
+
+  if (
+    !id ||
+    !title ||
+    !authorName ||
+    !createdAt ||
+    !permalink ||
+    comments === null ||
+    score === null
+  ) {
+    return null;
+  }
+
+  return {
+    id,
+    title,
+    authorName,
+    comments,
+    score,
+    createdAt,
+    permalink,
+  };
+};
+
+const createCommentEntityFromEvent = (
+  comment: CommentV2 | undefined,
+  post: PostV2 | undefined,
+  author: UserV2 | undefined
+): CommentEntity | null => {
+  if (!comment) {
+    return null;
+  }
+
+  const id = normalizeThingId(comment.id, 't1_');
+  const postId =
+    normalizeThingId(comment.postId, 't3_') ??
+    normalizeThingId(post?.id, 't3_');
+  const authorName =
+    readRequiredText(comment.author) ?? readRequiredText(author?.name);
+  const createdAt = readEventCreatedAt(comment.createdAt);
+  const permalink = readRequiredText(comment.permalink);
+  const score = readFiniteNumber(comment.score);
+
+  if (
+    !id ||
+    !postId ||
+    !authorName ||
+    !createdAt ||
+    !permalink ||
+    score === null
+  ) {
+    return null;
+  }
+
+  return {
+    id,
+    postId,
+    authorName,
+    score,
+    bodyPreview: createCommentBodyPreviewText(comment.body ?? ''),
+    createdAt,
+    permalink,
+  };
+};
+
+const upsertExistingParentPostFromEvent = async (
+  post: PostV2 | undefined,
+  dataLayer: EventDataLayer
+): Promise<boolean> => {
+  if (!post) {
+    return false;
+  }
+
+  const id = normalizeThingId(post.id, 't3_');
+
+  if (!id) {
+    return false;
+  }
+
+  const existingPost = await dataLayer.posts.getById(id);
+
+  if (!existingPost) {
+    return false;
+  }
+
+  await dataLayer.posts.upsert({
+    ...existingPost,
+    title: readRequiredText(post.title) ?? existingPost.title,
+    comments: readFiniteNumber(post.numComments) ?? existingPost.comments,
+    score: readFiniteNumber(post.score) ?? existingPost.score,
+    createdAt: readEventCreatedAt(post.createdAt) ?? existingPost.createdAt,
+    permalink: readRequiredText(post.permalink) ?? existingPost.permalink,
+  });
+
+  return true;
+};
+
+const createSkippedEventCacheResult = ({
+  subredditName,
+  skippedReason,
+  now,
+}: {
+  subredditName: string;
+  skippedReason: string;
+  now: () => Date;
+}): EventCacheResult => ({
+  status: 'skipped',
+  subredditName,
+  cachedPostCount: 0,
+  cachedCommentCount: 0,
+  refreshedContributorCount: 0,
+  generatedAt: now().toISOString(),
+  skippedReason,
+});
+
+const resolveEventSubredditName = (
+  subreddit: SubredditV2 | undefined,
+  currentSubredditName: string
+): string =>
+  normalizeSubredditName(
+    readRequiredText(subreddit?.name) ?? currentSubredditName
+  );
+
+const normalizeThingId = (
+  value: string | null | undefined,
+  prefix: 't1_' | 't3_'
+): string | null => {
+  const trimmed = value?.trim() ?? '';
+
+  if (trimmed === '') {
+    return null;
+  }
+
+  if (trimmed.startsWith(prefix)) {
+    return trimmed;
+  }
+
+  if (/^t\d_/.test(trimmed)) {
+    return null;
+  }
+
+  return `${prefix}${trimmed}`;
+};
+
+const readEventCreatedAt = (timestamp: number): string | null => {
+  if (!Number.isFinite(timestamp)) {
+    return null;
+  }
+
+  const timestampMs =
+    Math.abs(timestamp) < SECONDS_TIMESTAMP_THRESHOLD
+      ? timestamp * 1000
+      : timestamp;
+  const date = new Date(timestampMs);
+
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+};
+
+const readRequiredText = (value: string | null | undefined): string | null => {
+  const trimmed = value?.trim() ?? '';
+
+  return trimmed === '' ? null : trimmed;
+};
+
+const readFiniteNumber = (value: number): number | null =>
+  Number.isFinite(value) ? value : null;
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);

--- a/src/server/core/event-cache.ts
+++ b/src/server/core/event-cache.ts
@@ -1,10 +1,11 @@
-import { context } from '@devvit/web/server';
+import { context, reddit } from '@devvit/web/server';
 import type {
   CommentV2,
   OnCommentCreateRequest,
   OnPostCreateRequest,
   PostV2,
   SubredditV2,
+  T2,
   UserV2,
 } from '@devvit/web/shared';
 import { createDataLayer, type DataLayer } from '../data';
@@ -31,9 +32,12 @@ type EventContributorRefresh = (
   options: EventContributorRefreshOptions
 ) => Promise<number>;
 
+type EventUsernameResolver = (authorId: T2) => Promise<string | null>;
+
 export type EventCacheDependencies = {
   createDataLayerForSubreddit?: (subredditName: string) => EventDataLayer;
   refreshContributor?: EventContributorRefresh;
+  resolveUsernameById?: EventUsernameResolver;
   currentSubredditName?: string;
   now?: () => Date;
 };
@@ -53,6 +57,7 @@ export const cachePostCreateEvent = async (
   {
     createDataLayerForSubreddit = createDataLayer,
     refreshContributor = refreshEventContributor,
+    resolveUsernameById = resolveEventUsernameById,
     currentSubredditName = context.subredditName,
     now = () => new Date(),
   }: EventCacheDependencies = {}
@@ -61,7 +66,11 @@ export const cachePostCreateEvent = async (
     input.subreddit,
     currentSubredditName
   );
-  const post = createPostEntityFromEvent(input.post, input.author);
+  const post = await createPostEntityFromEvent(
+    input.post,
+    input.author,
+    resolveUsernameById
+  );
 
   if (!post) {
     return createSkippedEventCacheResult({
@@ -96,6 +105,7 @@ export const cacheCommentCreateEvent = async (
   {
     createDataLayerForSubreddit = createDataLayer,
     refreshContributor = refreshEventContributor,
+    resolveUsernameById = resolveEventUsernameById,
     currentSubredditName = context.subredditName,
     now = () => new Date(),
   }: EventCacheDependencies = {}
@@ -104,10 +114,11 @@ export const cacheCommentCreateEvent = async (
     input.subreddit,
     currentSubredditName
   );
-  const comment = createCommentEntityFromEvent(
+  const comment = await createCommentEntityFromEvent(
     input.comment,
     input.post,
-    input.author
+    input.author,
+    resolveUsernameById
   );
 
   if (!comment) {
@@ -148,6 +159,12 @@ const refreshEventContributor: EventContributorRefresh = async ({
   return result.refreshedContributorCount;
 };
 
+const resolveEventUsernameById: EventUsernameResolver = async (authorId) => {
+  const user = await reddit.getUserById(authorId);
+
+  return user?.username ?? null;
+};
+
 const refreshContributorForAuthor = async ({
   subredditName,
   authorName,
@@ -178,15 +195,28 @@ const refreshContributorForAuthor = async ({
 
 const createPostEntityFromEvent = (
   post: PostV2 | undefined,
-  author: UserV2 | undefined
-): PostEntity | null => {
+  author: UserV2 | undefined,
+  resolveUsernameById: EventUsernameResolver
+): Promise<PostEntity | null> => {
   if (!post) {
-    return null;
+    return Promise.resolve(null);
   }
 
+  return createPostEntityFromValidEvent(post, author, resolveUsernameById);
+};
+
+const createPostEntityFromValidEvent = async (
+  post: PostV2,
+  author: UserV2 | undefined,
+  resolveUsernameById: EventUsernameResolver
+): Promise<PostEntity | null> => {
   const id = normalizeThingId(post.id, 't3_');
   const title = readRequiredText(post.title);
-  const authorName = readRequiredText(author?.name);
+  const authorName = await resolveEventAuthorName({
+    candidates: [author?.name],
+    authorIds: [author?.id, post.authorId],
+    resolveUsernameById,
+  });
   const createdAt = readEventCreatedAt(post.createdAt);
   const permalink = readRequiredText(post.permalink);
   const comments = readFiniteNumber(post.numComments);
@@ -215,11 +245,12 @@ const createPostEntityFromEvent = (
   };
 };
 
-const createCommentEntityFromEvent = (
+const createCommentEntityFromEvent = async (
   comment: CommentV2 | undefined,
   post: PostV2 | undefined,
-  author: UserV2 | undefined
-): CommentEntity | null => {
+  author: UserV2 | undefined,
+  resolveUsernameById: EventUsernameResolver
+): Promise<CommentEntity | null> => {
   if (!comment) {
     return null;
   }
@@ -228,8 +259,11 @@ const createCommentEntityFromEvent = (
   const postId =
     normalizeThingId(comment.postId, 't3_') ??
     normalizeThingId(post?.id, 't3_');
-  const authorName =
-    readRequiredText(comment.author) ?? readRequiredText(author?.name);
+  const authorName = await resolveEventAuthorName({
+    candidates: [author?.name, comment.author],
+    authorIds: [author?.id],
+    resolveUsernameById,
+  });
   const createdAt = readEventCreatedAt(comment.createdAt);
   const permalink = readRequiredText(comment.permalink);
   const score = readFiniteNumber(comment.score);
@@ -254,6 +288,74 @@ const createCommentEntityFromEvent = (
     createdAt,
     permalink,
   };
+};
+
+const resolveEventAuthorName = async ({
+  candidates,
+  authorIds,
+  resolveUsernameById,
+}: {
+  candidates: Array<string | undefined>;
+  authorIds: Array<string | undefined>;
+  resolveUsernameById: EventUsernameResolver;
+}): Promise<string | null> => {
+  for (const candidate of candidates) {
+    const normalizedCandidate = readRequiredText(candidate);
+
+    if (!normalizedCandidate) {
+      continue;
+    }
+
+    if (!isThingId(normalizedCandidate)) {
+      return normalizedCandidate;
+    }
+
+    if (isAccountId(normalizedCandidate)) {
+      const username = await tryResolveUsernameById(
+        normalizedCandidate,
+        resolveUsernameById
+      );
+
+      if (username) {
+        return username;
+      }
+    }
+  }
+
+  for (const authorId of authorIds) {
+    const normalizedAuthorId = readRequiredText(authorId);
+
+    if (!isAccountId(normalizedAuthorId)) {
+      continue;
+    }
+
+    const username = await tryResolveUsernameById(
+      normalizedAuthorId,
+      resolveUsernameById
+    );
+
+    if (username) {
+      return username;
+    }
+  }
+
+  return null;
+};
+
+const tryResolveUsernameById = async (
+  authorId: T2,
+  resolveUsernameById: EventUsernameResolver
+): Promise<string | null> => {
+  try {
+    return readRequiredText(await resolveUsernameById(authorId));
+  } catch (error) {
+    logger.warn('Unable to resolve event author username by id', {
+      authorId,
+      error: getErrorMessage(error),
+    });
+
+    return null;
+  }
 };
 
 const upsertExistingParentPostFromEvent = async (
@@ -354,6 +456,11 @@ const readRequiredText = (value: string | null | undefined): string | null => {
 
   return trimmed === '' ? null : trimmed;
 };
+
+const isThingId = (value: string): boolean => /^t\d_/.test(value);
+
+const isAccountId = (value: string | null): value is T2 =>
+  value?.startsWith('t2_') ?? false;
 
 const readFiniteNumber = (value: number): number | null =>
   Number.isFinite(value) ? value : null;

--- a/src/server/routes/triggers.test.ts
+++ b/src/server/routes/triggers.test.ts
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict';
+import { beforeEach, expect, test, vi } from 'vitest';
+import {
+  cacheCommentCreateEvent,
+  cachePostCreateEvent,
+} from '../core/event-cache';
+import { triggers } from './triggers';
+
+vi.mock('@devvit/web/server', () => ({
+  context: {
+    subredditName: 'ExampleSub',
+  },
+}));
+
+vi.mock('../core/event-cache', () => ({
+  cachePostCreateEvent: vi.fn(),
+  cacheCommentCreateEvent: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.mocked(cachePostCreateEvent).mockReset();
+  vi.mocked(cacheCommentCreateEvent).mockReset();
+});
+
+test('post create trigger returns success after caching event data', async () => {
+  vi.mocked(cachePostCreateEvent).mockResolvedValue({
+    status: 'cached',
+    subredditName: 'examplesub',
+    cachedPostCount: 1,
+    cachedCommentCount: 0,
+    refreshedContributorCount: 1,
+    generatedAt: '2026-04-15T12:00:00.000Z',
+  });
+
+  const response = await triggers.request('/on-post-create', {
+    method: 'POST',
+    body: JSON.stringify({
+      type: 'PostCreate',
+      post: { id: 'post_1' },
+      subreddit: { name: 'ExampleSub' },
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  const body: unknown = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, {
+    status: 'success',
+    message: 'Post create event cached for r/examplesub',
+  });
+  expect(cachePostCreateEvent).toHaveBeenCalledWith({
+    type: 'PostCreate',
+    post: { id: 'post_1' },
+    subreddit: { name: 'ExampleSub' },
+  });
+});
+
+test('comment create trigger returns success after caching event data', async () => {
+  vi.mocked(cacheCommentCreateEvent).mockResolvedValue({
+    status: 'cached',
+    subredditName: 'examplesub',
+    cachedPostCount: 1,
+    cachedCommentCount: 1,
+    refreshedContributorCount: 1,
+    generatedAt: '2026-04-15T12:00:00.000Z',
+  });
+
+  const response = await triggers.request('/on-comment-create', {
+    method: 'POST',
+    body: JSON.stringify({
+      type: 'CommentCreate',
+      comment: { id: 'comment_1', postId: 'post_1' },
+      post: { id: 'post_1' },
+      subreddit: { name: 'ExampleSub' },
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  const body: unknown = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, {
+    status: 'success',
+    message: 'Comment create event cached for r/examplesub',
+  });
+  expect(cacheCommentCreateEvent).toHaveBeenCalledWith({
+    type: 'CommentCreate',
+    comment: { id: 'comment_1', postId: 'post_1' },
+    post: { id: 'post_1' },
+    subreddit: { name: 'ExampleSub' },
+  });
+});
+
+test('comment create trigger returns success when event data is skipped', async () => {
+  vi.mocked(cacheCommentCreateEvent).mockResolvedValue({
+    status: 'skipped',
+    subredditName: 'examplesub',
+    cachedPostCount: 0,
+    cachedCommentCount: 0,
+    refreshedContributorCount: 0,
+    generatedAt: '2026-04-15T12:00:00.000Z',
+    skippedReason: 'missing_or_invalid_comment_payload',
+  });
+
+  const response = await triggers.request('/on-comment-create', {
+    method: 'POST',
+    body: JSON.stringify({
+      type: 'CommentCreate',
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  const body: unknown = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, {
+    status: 'success',
+    message: 'Comment create event skipped for r/examplesub',
+  });
+});
+
+test('post create trigger returns an error response when caching fails', async () => {
+  vi.mocked(cachePostCreateEvent).mockRejectedValue(new Error('redis down'));
+
+  const response = await triggers.request('/on-post-create', {
+    method: 'POST',
+    body: JSON.stringify({
+      type: 'PostCreate',
+      post: { id: 'post_1' },
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  const body: unknown = await response.json();
+
+  assert.equal(response.status, 500);
+  assert.deepEqual(body, {
+    status: 'error',
+    message: 'Failed to cache post create event',
+  });
+});

--- a/src/server/routes/triggers.ts
+++ b/src/server/routes/triggers.ts
@@ -1,25 +1,37 @@
 import { Hono } from 'hono';
-import type { OnAppInstallRequest, TriggerResponse } from '@devvit/web/shared';
+import type {
+  OnAppInstallRequest,
+  OnCommentCreateRequest,
+  OnPostCreateRequest,
+  TriggerResponse,
+} from '@devvit/web/shared';
 import { context } from '@devvit/web/server';
 import {
   createAppCacheRefreshLogMetadata,
   refreshAppCachesForCurrentSubreddits,
 } from './cache';
+import {
+  cacheCommentCreateEvent,
+  cachePostCreateEvent,
+  type EventCacheResult,
+} from '../core/event-cache';
 import { createLogger } from '../logging/logger';
 
 export const triggers = new Hono();
-const logger = createLogger('triggers:on-app-install');
+const appInstallLogger = createLogger('triggers:on-app-install');
+const postCreateLogger = createLogger('triggers:on-post-create');
+const commentCreateLogger = createLogger('triggers:on-comment-create');
 
 triggers.post('/on-app-install', async (c) => {
   const input = await c.req.json<OnAppInstallRequest>();
-  logger.info('Received app install trigger', {
+  appInstallLogger.info('Received app install trigger', {
     currentSubredditName: context.subredditName,
     triggerType: input.type,
   });
 
   try {
     const result = await refreshAppCachesForCurrentSubreddits();
-    logger.info('Completed app install cache refresh', {
+    appInstallLogger.info('Completed app install cache refresh', {
       currentSubredditName: context.subredditName,
       triggerType: input.type,
       ...createAppCacheRefreshLogMetadata(result),
@@ -34,7 +46,7 @@ triggers.post('/on-app-install', async (c) => {
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    logger.error('App install cache refresh failed', {
+    appInstallLogger.error('App install cache refresh failed', {
       currentSubredditName: context.subredditName,
       triggerType: input.type,
       error: message,
@@ -49,3 +61,126 @@ triggers.post('/on-app-install', async (c) => {
     );
   }
 });
+
+triggers.post('/on-post-create', async (c) => {
+  const input = await c.req.json<OnPostCreateRequest>();
+  postCreateLogger.info('Received post create trigger', {
+    currentSubredditName: context.subredditName,
+    triggerType: input.type,
+    eventSubredditName: input.subreddit?.name ?? null,
+    postId: input.post?.id ?? null,
+  });
+
+  try {
+    const result = await cachePostCreateEvent(input);
+
+    logEventCacheResult(
+      postCreateLogger,
+      'Completed post create event cache update',
+      result
+    );
+
+    return c.json<TriggerResponse>(
+      {
+        status: 'success',
+        message:
+          result.status === 'cached'
+            ? `Post create event cached for r/${result.subredditName}`
+            : `Post create event skipped for r/${result.subredditName}`,
+      },
+      200
+    );
+  } catch (error) {
+    postCreateLogger.error('Post create event cache update failed', {
+      currentSubredditName: context.subredditName,
+      triggerType: input.type,
+      eventSubredditName: input.subreddit?.name ?? null,
+      postId: input.post?.id ?? null,
+      error: getErrorMessage(error),
+    });
+
+    return c.json<TriggerResponse>(
+      {
+        status: 'error',
+        message: 'Failed to cache post create event',
+      },
+      500
+    );
+  }
+});
+
+triggers.post('/on-comment-create', async (c) => {
+  const input = await c.req.json<OnCommentCreateRequest>();
+  commentCreateLogger.info('Received comment create trigger', {
+    currentSubredditName: context.subredditName,
+    triggerType: input.type,
+    eventSubredditName: input.subreddit?.name ?? null,
+    postId: input.post?.id ?? input.comment?.postId ?? null,
+    commentId: input.comment?.id ?? null,
+  });
+
+  try {
+    const result = await cacheCommentCreateEvent(input);
+
+    logEventCacheResult(
+      commentCreateLogger,
+      'Completed comment create event cache update',
+      result
+    );
+
+    return c.json<TriggerResponse>(
+      {
+        status: 'success',
+        message:
+          result.status === 'cached'
+            ? `Comment create event cached for r/${result.subredditName}`
+            : `Comment create event skipped for r/${result.subredditName}`,
+      },
+      200
+    );
+  } catch (error) {
+    commentCreateLogger.error('Comment create event cache update failed', {
+      currentSubredditName: context.subredditName,
+      triggerType: input.type,
+      eventSubredditName: input.subreddit?.name ?? null,
+      postId: input.post?.id ?? input.comment?.postId ?? null,
+      commentId: input.comment?.id ?? null,
+      error: getErrorMessage(error),
+    });
+
+    return c.json<TriggerResponse>(
+      {
+        status: 'error',
+        message: 'Failed to cache comment create event',
+      },
+      500
+    );
+  }
+});
+
+const logEventCacheResult = (
+  logger: ReturnType<typeof createLogger>,
+  message: string,
+  result: EventCacheResult
+): void => {
+  const metadata = {
+    currentSubredditName: context.subredditName,
+    subredditName: result.subredditName,
+    status: result.status,
+    cachedPostCount: result.cachedPostCount,
+    cachedCommentCount: result.cachedCommentCount,
+    refreshedContributorCount: result.refreshedContributorCount,
+    generatedAt: result.generatedAt,
+    skippedReason: result.skippedReason ?? null,
+  };
+
+  if (result.status === 'skipped') {
+    logger.warn(message, metadata);
+    return;
+  }
+
+  logger.info(message, metadata);
+};
+
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary
- Add `onPostCreate` and `onCommentCreate` trigger routes and register them in `devvit.json`
- Write post/comment entities to Redis immediately from trigger payloads, with contributor metadata refresh for valid authors
- Reuse existing comment preview and contributor metadata logic so scheduled cron refreshes remain as reconciliation

## Testing
- `npm run test`
- Added unit coverage for event conversion, Redis writes, no-op payloads, and trigger responses