### PR TITLE
Split contributor refresh into hourly seed and queue worker

### DIFF
--- a/devvit.json
+++ b/devvit.json
@@ -63,7 +63,11 @@
       },
       "refreshContributorCache": {
         "endpoint": "/internal/cache/refresh-contributor-cache",
-        "cron": "*/30 * * * *"
+        "cron": "0 * * * *"
+      },
+      "refreshContributorCacheQueue": {
+        "endpoint": "/internal/cache/refresh-contributor-cache-queue",
+        "cron": "*/30 * * * * *"
       },
       "refreshSubredditIcons": {
         "endpoint": "/internal/cache/refresh-subreddit-icons",

--- a/src/server/core/contributor-cache.test.ts
+++ b/src/server/core/contributor-cache.test.ts
@@ -1,7 +1,20 @@
+import assert from 'node:assert/strict';
 import { reddit } from '@devvit/web/server';
 import { beforeEach, expect, test, vi } from 'vitest';
-import type { ContributorEntity, ContributorRepository } from '../data';
-import { refreshContributorMetadata } from './contributor-cache';
+import {
+  createDataLayer,
+  getDataKeys,
+  type CommentEntity,
+  type ContributorEntity,
+  type ContributorRepository,
+  type PostEntity,
+  type RedisDataClient,
+} from '../data';
+import {
+  processContributorCacheQueue,
+  refreshContributorCache,
+  refreshContributorMetadata,
+} from './contributor-cache';
 
 vi.mock('@devvit/web/server', () => ({
   context: {
@@ -13,12 +26,338 @@ vi.mock('@devvit/web/server', () => ({
   },
 }));
 
+class FakeRedisClient implements RedisDataClient {
+  readonly hashes = new Map<string, Map<string, string>>();
+  readonly sortedSets = new Map<string, Map<string, number>>();
+
+  async hGet(key: string, field: string): Promise<string | undefined> {
+    return this.hashes.get(key)?.get(field);
+  }
+
+  async hMGet(key: string, fields: string[]): Promise<(string | null)[]> {
+    const hash = this.hashes.get(key);
+
+    return fields.map((field) => hash?.get(field) ?? null);
+  }
+
+  async hSet(
+    key: string,
+    fieldValues: { [field: string]: string }
+  ): Promise<number> {
+    const hash = this.hashes.get(key) ?? new Map<string, string>();
+    let addedFieldCount = 0;
+
+    Object.entries(fieldValues).forEach(([field, value]) => {
+      if (!hash.has(field)) {
+        addedFieldCount += 1;
+      }
+
+      hash.set(field, value);
+    });
+
+    this.hashes.set(key, hash);
+    return addedFieldCount;
+  }
+
+  async del(...keys: string[]): Promise<void> {
+    keys.forEach((key) => {
+      this.hashes.delete(key);
+      this.sortedSets.delete(key);
+    });
+  }
+
+  async zAdd(
+    key: string,
+    ...members: Array<{ member: string; score: number }>
+  ): Promise<number> {
+    const sortedSet = this.sortedSets.get(key) ?? new Map<string, number>();
+    let addedMemberCount = 0;
+
+    members.forEach(({ member, score }) => {
+      if (!sortedSet.has(member)) {
+        addedMemberCount += 1;
+      }
+
+      sortedSet.set(member, score);
+    });
+
+    this.sortedSets.set(key, sortedSet);
+    return addedMemberCount;
+  }
+
+  async zRange(
+    key: string,
+    start: number | string,
+    stop: number | string,
+    options?: Parameters<RedisDataClient['zRange']>[3]
+  ): Promise<Array<{ member: string; score: number }>> {
+    const sortedMembers = this.readSortedSet(key);
+
+    if (options?.by === 'rank') {
+      const rankedMembers = options.reverse
+        ? sortedMembers.toReversed()
+        : sortedMembers;
+      const startRank = Number(start);
+      const stopRank = Number(stop);
+      const endRank = stopRank < 0 ? rankedMembers.length + stopRank : stopRank;
+
+      return rankedMembers.slice(startRank, endRank + 1);
+    }
+
+    const startScore = Number(start);
+    const stopScore = Number(stop);
+    const matchedMembers = sortedMembers.filter(
+      ({ score }) => score >= startScore && score <= stopScore
+    );
+    const orderedMembers = options?.reverse
+      ? matchedMembers.toReversed()
+      : matchedMembers;
+
+    if (options?.limit) {
+      return orderedMembers.slice(
+        options.limit.offset,
+        options.limit.offset + options.limit.count
+      );
+    }
+
+    return orderedMembers;
+  }
+
+  async zRem(key: string, members: string[]): Promise<number> {
+    const sortedSet = this.sortedSets.get(key);
+
+    if (!sortedSet) {
+      return 0;
+    }
+
+    let removedMemberCount = 0;
+
+    members.forEach((member) => {
+      if (sortedSet.delete(member)) {
+        removedMemberCount += 1;
+      }
+    });
+
+    return removedMemberCount;
+  }
+
+  readSortedSet(key: string): Array<{ member: string; score: number }> {
+    return [...(this.sortedSets.get(key)?.entries() ?? [])]
+      .map(([member, score]) => ({ member, score }))
+      .sort(
+        (left, right) =>
+          left.score - right.score || left.member.localeCompare(right.member)
+      );
+  }
+}
+
 beforeEach(() => {
   vi.mocked(reddit.getUserKarmaFromCurrentSubreddit).mockReset();
   vi.mocked(reddit.getSnoovatarUrl).mockReset();
   vi.mocked(reddit.getSnoovatarUrl).mockResolvedValue(
     'https://example.com/avatar.png'
   );
+});
+
+test('refreshContributorCache replaces stale queue entries and orders contributors by latest activity', async () => {
+  const redisClient = new FakeRedisClient();
+  const dataLayer = createDataLayer('ExampleSub', redisClient);
+  const keys = getDataKeys('ExampleSub');
+
+  await dataLayer.posts.upsertMany([
+    createPost('t3_post_bob', '2026-04-15T10:00:00.000Z', 'bob'),
+    createPost('t3_post_alice', '2026-04-15T11:00:00.000Z', 'alice'),
+  ]);
+  await dataLayer.comments.upsertMany([
+    createComment('t1_comment_bob', '2026-04-15T12:00:00.000Z', 'bob'),
+    createComment('t1_comment_carol', '2026-04-15T12:00:00.000Z', 'carol'),
+    createComment(
+      't1_comment_deleted',
+      '2026-04-15T12:30:00.000Z',
+      '[deleted]'
+    ),
+    createComment('t1_comment_blank', '2026-04-15T13:00:00.000Z', '   '),
+  ]);
+  await redisClient.zAdd(keys.contributorRefreshQueue, {
+    member: 'stale-user',
+    score: 99,
+  });
+
+  const result = await refreshContributorCache('ExampleSub', {
+    createDataLayerForSubreddit: () => dataLayer,
+    redisClient,
+    now: () => new Date('2026-04-15T12:45:00.000Z'),
+  });
+
+  assert.deepEqual(result, {
+    candidateContributorCount: 3,
+    enqueuedContributorCount: 3,
+    generatedAt: '2026-04-15T12:45:00.000Z',
+  });
+  assert.deepEqual(redisClient.readSortedSet(keys.contributorRefreshQueue), [
+    { member: 'bob', score: 0 },
+    { member: 'carol', score: 1 },
+    { member: 'alice', score: 2 },
+  ]);
+});
+
+test('processContributorCacheQueue refreshes contributors in queue order until empty', async () => {
+  const redisClient = new FakeRedisClient();
+  const dataLayer = createDataLayer('ExampleSub', redisClient);
+  const refreshedUsernames: string[] = [];
+
+  await dataLayer.posts.upsertMany([
+    createPost('t3_post_bob', '2026-04-15T10:00:00.000Z', 'bob'),
+    createPost('t3_post_alice', '2026-04-15T11:00:00.000Z', 'alice'),
+  ]);
+  await dataLayer.comments.upsertMany([
+    createComment('t1_comment_bob', '2026-04-15T12:00:00.000Z', 'bob'),
+    createComment('t1_comment_carol', '2026-04-15T12:00:00.000Z', 'carol'),
+  ]);
+
+  await refreshContributorCache('ExampleSub', {
+    createDataLayerForSubreddit: () => dataLayer,
+    redisClient,
+    now: () => new Date('2026-04-15T12:45:00.000Z'),
+  });
+
+  const result = await processContributorCacheQueue(
+    { subredditName: 'ExampleSub', maxDurationMs: 25_000 },
+    {
+      redisClient,
+      refreshContributorMetadataForUser: async (_subredditName, username) => {
+        refreshedUsernames.push(username);
+
+        return {
+          refreshedContributorCount: 1,
+          generatedAt: '2026-04-15T12:45:00.000Z',
+        };
+      },
+      now: () => 0,
+    }
+  );
+
+  assert.deepEqual(refreshedUsernames, ['bob', 'carol', 'alice']);
+  assert.deepEqual(result, {
+    processedContributorCount: 3,
+    refreshedContributorCount: 3,
+    failedItemCount: 0,
+    invalidQueueItemCount: 0,
+    queueEmpty: true,
+    generatedAt: '1970-01-01T00:00:00.000Z',
+  });
+});
+
+test('processContributorCacheQueue stops when the time budget is exhausted', async () => {
+  const redisClient = new FakeRedisClient();
+  const keys = getDataKeys('ExampleSub');
+  const refreshedUsernames: string[] = [];
+
+  await redisClient.zAdd(
+    keys.contributorRefreshQueue,
+    { member: 'alice', score: 0 },
+    { member: 'bob', score: 1 }
+  );
+
+  const result = await processContributorCacheQueue(
+    { subredditName: 'ExampleSub', maxDurationMs: 25_000 },
+    {
+      redisClient,
+      refreshContributorMetadataForUser: async (_subredditName, username) => {
+        refreshedUsernames.push(username);
+
+        return {
+          refreshedContributorCount: 1,
+          generatedAt: '2026-04-15T12:45:00.000Z',
+        };
+      },
+      now: createNow([0, 0, 30_000, 30_000]),
+    }
+  );
+
+  assert.deepEqual(refreshedUsernames, ['alice']);
+  assert.equal(result.processedContributorCount, 1);
+  assert.equal(result.refreshedContributorCount, 1);
+  assert.equal(result.queueEmpty, false);
+  assert.deepEqual(redisClient.readSortedSet(keys.contributorRefreshQueue), [
+    { member: 'bob', score: 1 },
+  ]);
+});
+
+test('processContributorCacheQueue skips invalid queue members and continues', async () => {
+  const redisClient = new FakeRedisClient();
+  const keys = getDataKeys('ExampleSub');
+  const refreshedUsernames: string[] = [];
+
+  await redisClient.zAdd(
+    keys.contributorRefreshQueue,
+    { member: '   ', score: 0 },
+    { member: 'alice', score: 1 }
+  );
+
+  const result = await processContributorCacheQueue(
+    { subredditName: 'ExampleSub', maxDurationMs: 25_000 },
+    {
+      redisClient,
+      refreshContributorMetadataForUser: async (_subredditName, username) => {
+        refreshedUsernames.push(username);
+
+        return {
+          refreshedContributorCount: 1,
+          generatedAt: '2026-04-15T12:45:00.000Z',
+        };
+      },
+      now: () => 0,
+    }
+  );
+
+  assert.deepEqual(refreshedUsernames, ['alice']);
+  assert.equal(result.processedContributorCount, 1);
+  assert.equal(result.invalidQueueItemCount, 1);
+  assert.equal(result.failedItemCount, 0);
+  assert.equal(result.queueEmpty, true);
+});
+
+test('processContributorCacheQueue continues after refresh failures', async () => {
+  const redisClient = new FakeRedisClient();
+  const keys = getDataKeys('ExampleSub');
+  const attemptedUsernames: string[] = [];
+
+  await redisClient.zAdd(
+    keys.contributorRefreshQueue,
+    { member: 'alice', score: 0 },
+    { member: 'bob', score: 1 }
+  );
+
+  const result = await processContributorCacheQueue(
+    { subredditName: 'ExampleSub', maxDurationMs: 25_000 },
+    {
+      redisClient,
+      refreshContributorMetadataForUser: async (_subredditName, username) => {
+        attemptedUsernames.push(username);
+
+        if (username === 'alice') {
+          throw new Error('reddit unavailable');
+        }
+
+        return {
+          refreshedContributorCount: 1,
+          generatedAt: '2026-04-15T12:45:00.000Z',
+        };
+      },
+      now: () => 0,
+    }
+  );
+
+  assert.deepEqual(attemptedUsernames, ['alice', 'bob']);
+  assert.deepEqual(result, {
+    processedContributorCount: 2,
+    refreshedContributorCount: 1,
+    failedItemCount: 1,
+    invalidQueueItemCount: 0,
+    queueEmpty: true,
+    generatedAt: '1970-01-01T00:00:00.000Z',
+  });
 });
 
 test('refreshContributorMetadata uses synthetic karma for non-current subreddits', async () => {
@@ -93,3 +432,42 @@ const createContributorRepository = (
   },
   upsertMany: async () => {},
 });
+
+const createPost = (
+  id: string,
+  createdAt: string,
+  authorName: string
+): PostEntity => ({
+  id,
+  title: `Post ${id}`,
+  authorName,
+  comments: 3,
+  score: 10,
+  createdAt,
+  permalink: `/r/example/comments/${id}`,
+});
+
+const createComment = (
+  id: string,
+  createdAt: string,
+  authorName: string
+): CommentEntity => ({
+  id,
+  postId: 't3_post_parent',
+  authorName,
+  score: 5,
+  bodyPreview: `Comment ${id}`,
+  createdAt,
+  permalink: `/r/example/comments/t3_post_parent/${id}`,
+});
+
+const createNow = (values: number[]): (() => number) => {
+  let index = 0;
+
+  return () => {
+    const value = values[Math.min(index, values.length - 1)] ?? 0;
+    index += 1;
+
+    return value;
+  };
+};

--- a/src/server/core/contributor-cache.ts
+++ b/src/server/core/contributor-cache.ts
@@ -1,6 +1,6 @@
-import { context, reddit } from '@devvit/web/server';
+import { context, reddit, redis } from '@devvit/web/server';
 import { resolveUserAvatarUrl } from '../../shared/api';
-import { createDataLayer } from '../data';
+import { createDataLayer, getDataKeys } from '../data';
 import type {
   ContributorEntity,
   CommentEntity,
@@ -11,15 +11,50 @@ import { createLogger } from '../logging/logger';
 import { shouldUseSyntheticContributorKarma } from './subreddits';
 
 const logger = createLogger('contributor-cache');
-const CONTRIBUTOR_METADATA_CONCURRENCY = 4;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const CONTRIBUTOR_LOOKBACK_MS = 90 * DAY_MS;
+export const CONTRIBUTOR_REFRESH_QUEUE_WORKER_DURATION_MS = 25 * 1000;
 const SYNTHETIC_KARMA_MIN = -100;
 const SYNTHETIC_KARMA_MAX = 50_000;
+const REDIS_QUEUE_CHUNK_SIZE = 100;
+
+type ContributorRefreshQueueRedisClient = Pick<
+  typeof redis,
+  'del' | 'zAdd' | 'zRange' | 'zRem'
+>;
+
+type ContributorQueueSeedCandidate = {
+  username: string;
+  lastContributionTimeMs: number;
+};
+
+type ContributorQueueItem =
+  | {
+      kind: 'valid';
+      username: string;
+    }
+  | {
+      kind: 'invalid';
+      member: string;
+    };
 
 export type ContributorCacheRefreshResult = {
   candidateContributorCount: number;
+  enqueuedContributorCount: number;
+  generatedAt: string;
+};
+
+export type ContributorCacheQueueProcessOptions = {
+  subredditName: string;
+  maxDurationMs?: number;
+};
+
+export type ContributorCacheQueueProcessResult = {
+  processedContributorCount: number;
   refreshedContributorCount: number;
+  failedItemCount: number;
+  invalidQueueItemCount: number;
+  queueEmpty: boolean;
   generatedAt: string;
 };
 
@@ -31,8 +66,8 @@ export type ContributorMetadataRefreshResult = {
 export type ContributorCacheDependencies = {
   createDataLayerForSubreddit?: (
     subredditName: string
-  ) => Pick<DataLayer, 'posts' | 'comments' | 'contributors'>;
-  currentSubredditName?: string;
+  ) => Pick<DataLayer, 'posts' | 'comments'>;
+  redisClient?: ContributorRefreshQueueRedisClient;
   now?: () => Date;
 };
 
@@ -44,15 +79,29 @@ export type ContributorMetadataRefreshDependencies = {
   now?: () => Date;
 };
 
+export type ContributorCacheQueueProcessDependencies = {
+  redisClient?: ContributorRefreshQueueRedisClient;
+  refreshContributorMetadataForUser?: (
+    subredditName: string,
+    username: string,
+    dependencies: ContributorMetadataRefreshDependencies
+  ) => Promise<ContributorMetadataRefreshResult>;
+  createDataLayerForSubreddit?: (
+    subredditName: string
+  ) => Pick<DataLayer, 'contributors'>;
+  currentSubredditName?: string;
+  now?: () => number;
+};
+
 export const refreshContributorCache = async (
   subredditName: string,
   {
     createDataLayerForSubreddit = createDataLayer,
-    currentSubredditName = context.subredditName,
+    redisClient = redis,
     now = () => new Date(),
   }: ContributorCacheDependencies = {}
 ): Promise<ContributorCacheRefreshResult> => {
-  logger.info('Refreshing contributor cache', { subredditName });
+  logger.info('Seeding contributor cache refresh queue', { subredditName });
 
   try {
     const dataLayer = createDataLayerForSubreddit(subredditName);
@@ -67,49 +116,127 @@ export const refreshContributorCache = async (
         endTime: fetchedAt.getTime() + DAY_MS,
       }),
     ]);
-    const usernames = getUniqueRefreshableContributorNames(posts, comments);
-    const useSyntheticContributorKarma = shouldUseSyntheticContributorKarma(
-      currentSubredditName,
-      subredditName
-    );
+    const candidates = createContributorQueueSeedCandidates(posts, comments);
+    const queueKey = getContributorRefreshQueueKey(subredditName);
 
-    logger.info('Loaded contributor cache candidates', {
+    await redisClient.del(queueKey);
+
+    const enqueuedContributorCount = await enqueueContributorQueueItems(
+      redisClient,
+      queueKey,
+      candidates.map(({ username }) => username)
+    );
+    const result = {
+      candidateContributorCount: candidates.length,
+      enqueuedContributorCount,
+      generatedAt: fetchedAt.toISOString(),
+    };
+
+    logger.info('Seeded contributor cache refresh queue', {
       subredditName,
       postCount: posts.length,
       commentCount: comments.length,
-      candidateContributorCount: usernames.length,
-      useSyntheticContributorKarma,
-    });
-
-    const refreshedContributors = await mapWithConcurrency(
-      usernames,
-      CONTRIBUTOR_METADATA_CONCURRENCY,
-      async (username) =>
-        await getContributorEntity(
-          username,
-          fetchedAt,
-          useSyntheticContributorKarma
-        )
-    );
-
-    await dataLayer.contributors.upsertMany(refreshedContributors);
-
-    const result = {
-      candidateContributorCount: usernames.length,
-      refreshedContributorCount: refreshedContributors.length,
-      generatedAt: now().toISOString(),
-    };
-
-    logger.info('Stored contributor cache entries', {
-      subredditName,
       candidateContributorCount: result.candidateContributorCount,
-      refreshedContributorCount: result.refreshedContributorCount,
+      enqueuedContributorCount: result.enqueuedContributorCount,
       generatedAt: result.generatedAt,
     });
 
     return result;
   } catch (error) {
-    logger.error('Contributor cache refresh failed', {
+    logger.error('Contributor cache refresh queue seed failed', {
+      subredditName,
+      error: getErrorMessage(error),
+    });
+    throw error;
+  }
+};
+
+export const processContributorCacheQueue = async (
+  {
+    subredditName,
+    maxDurationMs = CONTRIBUTOR_REFRESH_QUEUE_WORKER_DURATION_MS,
+  }: ContributorCacheQueueProcessOptions,
+  {
+    redisClient = redis,
+    refreshContributorMetadataForUser = refreshContributorMetadata,
+    createDataLayerForSubreddit = createDataLayer,
+    currentSubredditName = context.subredditName,
+    now = Date.now,
+  }: ContributorCacheQueueProcessDependencies = {}
+): Promise<ContributorCacheQueueProcessResult> => {
+  logger.info('Processing contributor cache refresh queue', {
+    subredditName,
+    maxDurationMs,
+  });
+
+  const startedAt = now();
+  const queueKey = getContributorRefreshQueueKey(subredditName);
+  const result: ContributorCacheQueueProcessResult = {
+    processedContributorCount: 0,
+    refreshedContributorCount: 0,
+    failedItemCount: 0,
+    invalidQueueItemCount: 0,
+    queueEmpty: false,
+    generatedAt: new Date(startedAt).toISOString(),
+  };
+
+  try {
+    while (now() - startedAt < maxDurationMs) {
+      const item = await dequeueNextContributorQueueItem(redisClient, queueKey);
+
+      if (!item) {
+        result.queueEmpty = true;
+        break;
+      }
+
+      if (item.kind === 'invalid') {
+        result.invalidQueueItemCount += 1;
+        logger.warn('Skipped invalid contributor refresh queue item', {
+          subredditName,
+          member: item.member,
+        });
+        continue;
+      }
+
+      result.processedContributorCount += 1;
+
+      try {
+        const refreshResult = await refreshContributorMetadataForUser(
+          subredditName,
+          item.username,
+          {
+            createDataLayerForSubreddit,
+            currentSubredditName,
+          }
+        );
+
+        result.refreshedContributorCount +=
+          refreshResult.refreshedContributorCount;
+      } catch (error) {
+        result.failedItemCount += 1;
+        logger.warn('Unable to refresh contributor metadata from queue', {
+          subredditName,
+          username: item.username,
+          error: getErrorMessage(error),
+        });
+      }
+    }
+
+    result.generatedAt = new Date(now()).toISOString();
+
+    logger.info('Processed contributor cache refresh queue', {
+      subredditName,
+      processedContributorCount: result.processedContributorCount,
+      refreshedContributorCount: result.refreshedContributorCount,
+      failedItemCount: result.failedItemCount,
+      invalidQueueItemCount: result.invalidQueueItemCount,
+      queueEmpty: result.queueEmpty,
+      generatedAt: result.generatedAt,
+    });
+
+    return result;
+  } catch (error) {
+    logger.error('Contributor cache refresh queue processing failed', {
       subredditName,
       error: getErrorMessage(error),
     });
@@ -231,20 +358,105 @@ const getContributorAvatarUrl = async (username: string): Promise<string> => {
   }
 };
 
-const getUniqueRefreshableContributorNames = (
+const createContributorQueueSeedCandidates = (
   posts: PostEntity[],
   comments: CommentEntity[]
-): string[] =>
-  Array.from(
-    new Set(
-      [
-        ...posts.map((post) => post.authorName),
-        ...comments.map((comment) => comment.authorName),
-      ]
-        .map(readRefreshableContributorName)
-        .filter((username): username is string => username !== null)
-    )
-  );
+): ContributorQueueSeedCandidate[] => {
+  const latestContributionTimes = new Map<string, number>();
+
+  [...posts, ...comments].forEach((entity) => {
+    const username = readRefreshableContributorName(entity.authorName);
+
+    if (!username) {
+      return;
+    }
+
+    const createdAt = Date.parse(entity.createdAt);
+
+    if (!Number.isFinite(createdAt)) {
+      return;
+    }
+
+    const latestContributionTimeMs = latestContributionTimes.get(username);
+
+    if (
+      latestContributionTimeMs === undefined ||
+      createdAt > latestContributionTimeMs
+    ) {
+      latestContributionTimes.set(username, createdAt);
+    }
+  });
+
+  return [...latestContributionTimes.entries()]
+    .map(([username, lastContributionTimeMs]) => ({
+      username,
+      lastContributionTimeMs,
+    }))
+    .sort(
+      (left, right) =>
+        right.lastContributionTimeMs - left.lastContributionTimeMs ||
+        left.username.localeCompare(right.username)
+    );
+};
+
+const getContributorRefreshQueueKey = (subredditName: string): string =>
+  getDataKeys(subredditName).contributorRefreshQueue;
+
+const enqueueContributorQueueItems = async (
+  redisClient: ContributorRefreshQueueRedisClient,
+  queueKey: string,
+  usernames: string[]
+): Promise<number> => {
+  if (usernames.length === 0) {
+    return 0;
+  }
+
+  let enqueuedContributorCount = 0;
+
+  for (
+    let start = 0;
+    start < usernames.length;
+    start += REDIS_QUEUE_CHUNK_SIZE
+  ) {
+    const chunk = usernames.slice(start, start + REDIS_QUEUE_CHUNK_SIZE);
+
+    enqueuedContributorCount += await redisClient.zAdd(
+      queueKey,
+      ...chunk.map((member, index) => ({
+        member,
+        score: start + index,
+      }))
+    );
+  }
+
+  return enqueuedContributorCount;
+};
+
+const dequeueNextContributorQueueItem = async (
+  redisClient: ContributorRefreshQueueRedisClient,
+  queueKey: string
+): Promise<ContributorQueueItem | null> => {
+  const nextItems = await redisClient.zRange(queueKey, 0, 0, { by: 'rank' });
+  const nextItem = nextItems[0];
+
+  if (!nextItem) {
+    return null;
+  }
+
+  await redisClient.zRem(queueKey, [nextItem.member]);
+
+  const username = readRefreshableContributorName(nextItem.member);
+
+  return username
+    ? {
+        kind: 'valid',
+        username,
+      }
+    : {
+        kind: 'invalid',
+        member: nextItem.member,
+      };
+};
 
 const getSyntheticContributorKarma = (): number =>
   randomInteger(SYNTHETIC_KARMA_MIN, SYNTHETIC_KARMA_MAX);
@@ -258,32 +470,6 @@ const sumKarma = (karma: GetUserKarmaForSubredditResponse): number =>
 type GetUserKarmaForSubredditResponse = {
   fromPosts?: number | undefined;
   fromComments?: number | undefined;
-};
-
-const mapWithConcurrency = async <Input, Output>(
-  items: Input[],
-  limit: number,
-  mapper: (item: Input) => Promise<Output>
-): Promise<Output[]> => {
-  const results = new Array<Output | undefined>(items.length);
-  let nextIndex = 0;
-  const workerCount = Math.min(limit, items.length);
-
-  await Promise.all(
-    Array.from({ length: workerCount }, async () => {
-      while (nextIndex < items.length) {
-        const index = nextIndex;
-        nextIndex += 1;
-        const item = items[index];
-
-        if (item !== undefined) {
-          results[index] = await mapper(item);
-        }
-      }
-    })
-  );
-
-  return results.filter((result): result is Output => result !== undefined);
 };
 
 const getErrorMessage = (error: unknown): string =>

--- a/src/server/core/subreddits.test.ts
+++ b/src/server/core/subreddits.test.ts
@@ -36,7 +36,7 @@ test('active refresh subreddit normalizes the override value', () => {
 
 test('active refresh subreddit uses the configured development override by default', () => {
   expect(resolveActiveRefreshSubredditName('bubblesneverlie_dev')).toBe(
-    'wallstreetbets'
+    'redditstock'
   );
 });
 

--- a/src/server/core/subreddits.ts
+++ b/src/server/core/subreddits.ts
@@ -10,7 +10,7 @@ type AppEnvironmentConfig = {
 // keep the per-environment refresh-source config in code.
 const APP_ENVIRONMENTS: Record<AppEnvironmentName, AppEnvironmentConfig> = {
   development: {
-    activeRefreshSubredditName: 'wallstreetbets',
+    activeRefreshSubredditName: 'redditstock',
   },
   production: {},
 };

--- a/src/server/data/data-layer.test.ts
+++ b/src/server/data/data-layer.test.ts
@@ -120,6 +120,7 @@ test('data keys use app-local prefixes', () => {
     commentRefreshPostQueue: 'data:v1:examplesub:comments:refresh:posts',
     commentRefreshCommentQueue: 'data:v1:examplesub:comments:refresh:comments',
     contributors: 'data:v1:examplesub:contributors',
+    contributorRefreshQueue: 'data:v1:examplesub:contributors:refresh',
   });
 });
 

--- a/src/server/data/keys.ts
+++ b/src/server/data/keys.ts
@@ -10,6 +10,7 @@ export type DataKeys = {
   commentRefreshPostQueue: string;
   commentRefreshCommentQueue: string;
   contributors: string;
+  contributorRefreshQueue: string;
 };
 
 export const getDataKeys = (subredditName: string): DataKeys => {
@@ -23,5 +24,6 @@ export const getDataKeys = (subredditName: string): DataKeys => {
     commentRefreshPostQueue: `${baseKey}:comments:refresh:posts`,
     commentRefreshCommentQueue: `${baseKey}:comments:refresh:comments`,
     contributors: `${baseKey}:contributors`,
+    contributorRefreshQueue: `${baseKey}:contributors:refresh`,
   };
 };

--- a/src/server/routes/cache.ts
+++ b/src/server/routes/cache.ts
@@ -1,6 +1,9 @@
 import { context } from '@devvit/web/server';
 import { Hono } from 'hono';
-import { refreshContributorCache } from '../core/contributor-cache';
+import {
+  processContributorCacheQueue,
+  refreshContributorCache,
+} from '../core/contributor-cache';
 import {
   processCommentCacheQueue,
   refreshCommentCache,
@@ -15,9 +18,10 @@ const cachePostsLogger = createLogger('cache:posts');
 const cacheCommentsLogger = createLogger('cache:comments');
 const cacheCommentQueueLogger = createLogger('cache:comments-queue');
 const cacheContributorsLogger = createLogger('cache:contributors');
+const cacheContributorQueueLogger = createLogger('cache:contributors-queue');
 const cacheSubredditIconsLogger = createLogger('cache:subreddit-icons');
 const cacheAppLogger = createLogger('cache:app');
-const COMMENT_QUEUE_WORKER_ROUTE_DURATION_MS = 25 * 1000;
+const CACHE_QUEUE_WORKER_ROUTE_DURATION_MS = 25 * 1000;
 
 cache.post('/refresh-post-cache', async (c) => {
   cachePostsLogger.info(
@@ -173,7 +177,7 @@ cache.post('/refresh-contributor-cache', async (c) => {
         results: results.map(({ subredditName, result }) => ({
           subredditName,
           candidateContributorCount: result.candidateContributorCount,
-          refreshedContributorCount: result.refreshedContributorCount,
+          enqueuedContributorCount: result.enqueuedContributorCount,
         })),
       }
     );
@@ -191,6 +195,57 @@ cache.post('/refresh-contributor-cache', async (c) => {
       ...createContextLogMetadata(),
       error: message,
     });
+
+    return c.json(
+      {
+        status: 'error',
+        message,
+      },
+      500
+    );
+  }
+});
+
+cache.post('/refresh-contributor-cache-queue', async (c) => {
+  cacheContributorQueueLogger.info(
+    'Received contributor cache queue refresh request',
+    createContextLogMetadata()
+  );
+
+  try {
+    const results = await processContributorCacheQueuesForActiveSubreddit();
+    cacheContributorQueueLogger.info(
+      'Completed contributor cache queue refresh request',
+      {
+        ...createContextLogMetadata(),
+        subredditCount: results.length,
+        results: results.map(({ subredditName, result }) => ({
+          subredditName,
+          processedContributorCount: result.processedContributorCount,
+          refreshedContributorCount: result.refreshedContributorCount,
+          failedItemCount: result.failedItemCount,
+          invalidQueueItemCount: result.invalidQueueItemCount,
+          queueEmpty: result.queueEmpty,
+        })),
+      }
+    );
+
+    return c.json(
+      {
+        status: 'ok',
+        results,
+      },
+      200
+    );
+  } catch (error) {
+    const message = getErrorMessage(error);
+    cacheContributorQueueLogger.error(
+      'Contributor cache queue refresh request failed',
+      {
+        ...createContextLogMetadata(),
+        error: message,
+      }
+    );
 
     return c.json(
       {
@@ -385,7 +440,7 @@ const processCommentCacheQueuesForActiveSubreddit = async () => {
   try {
     const result = await processCommentCacheQueue({
       subredditName,
-      maxDurationMs: COMMENT_QUEUE_WORKER_ROUTE_DURATION_MS,
+      maxDurationMs: CACHE_QUEUE_WORKER_ROUTE_DURATION_MS,
     });
     cacheCommentQueueLogger.info(
       'Processed comment cache queue for subreddit',
@@ -422,31 +477,82 @@ const refreshContributorCachesForActiveSubreddit = async () => {
   const subredditName = resolveActiveRefreshSubredditName(
     context.subredditName
   );
-  cacheContributorsLogger.info('Refreshing contributor cache for subreddit', {
-    ...createContextLogMetadata(),
-    subredditName,
-  });
+  cacheContributorsLogger.info(
+    'Seeding contributor cache refresh queue for subreddit',
+    {
+      ...createContextLogMetadata(),
+      subredditName,
+    }
+  );
 
   try {
     const result = await refreshContributorCache(subredditName);
-    cacheContributorsLogger.info('Refreshed contributor cache for subreddit', {
-      subredditName,
-      candidateContributorCount: result.candidateContributorCount,
-      refreshedContributorCount: result.refreshedContributorCount,
-    });
+    cacheContributorsLogger.info(
+      'Seeded contributor cache refresh queue for subreddit',
+      {
+        subredditName,
+        candidateContributorCount: result.candidateContributorCount,
+        enqueuedContributorCount: result.enqueuedContributorCount,
+      }
+    );
 
     return [{ subredditName, result }];
   } catch (error) {
     const message = getErrorMessage(error);
     cacheContributorsLogger.warn(
-      'Contributor cache refresh failed for subreddit',
+      'Contributor cache refresh queue seed failed for subreddit',
       {
         subredditName,
         error: message,
       }
     );
     throw new Error(
-      `Unable to refresh contributor cache for r/${subredditName}: ${message}`
+      `Unable to seed contributor cache refresh queue for r/${subredditName}: ${message}`
+    );
+  }
+};
+
+const processContributorCacheQueuesForActiveSubreddit = async () => {
+  const subredditName = resolveActiveRefreshSubredditName(
+    context.subredditName
+  );
+  cacheContributorQueueLogger.info(
+    'Processing contributor cache queue for subreddit',
+    {
+      ...createContextLogMetadata(),
+      subredditName,
+    }
+  );
+
+  try {
+    const result = await processContributorCacheQueue({
+      subredditName,
+      maxDurationMs: CACHE_QUEUE_WORKER_ROUTE_DURATION_MS,
+    });
+    cacheContributorQueueLogger.info(
+      'Processed contributor cache queue for subreddit',
+      {
+        subredditName,
+        processedContributorCount: result.processedContributorCount,
+        refreshedContributorCount: result.refreshedContributorCount,
+        failedItemCount: result.failedItemCount,
+        invalidQueueItemCount: result.invalidQueueItemCount,
+        queueEmpty: result.queueEmpty,
+      }
+    );
+
+    return [{ subredditName, result }];
+  } catch (error) {
+    const message = getErrorMessage(error);
+    cacheContributorQueueLogger.warn(
+      'Contributor cache queue processing failed for subreddit',
+      {
+        subredditName,
+        error: message,
+      }
+    );
+    throw new Error(
+      `Unable to process contributor cache queue for r/${subredditName}: ${message}`
     );
   }
 };


### PR DESCRIPTION
## Summary
- Split contributor refresh into an hourly seeding job and a 30-second queue worker.
- Order queued contributors by latest contribution time so the most active users refresh first.
- Add a dedicated contributor refresh queue in Redis and update cache routes and scheduler entries accordingly.
- Cover the new seeding, ordering, dequeue, timeout, invalid-item, and failure cases with unit tests.

## Testing
- Unit tests added and updated for contributor cache seeding and queue processing.
- Unit tests updated for data key coverage and contributor refresh event behavior.