### PR TITLE
Add delete-trigger handling and Redis retention

### DIFF
--- a/devvit.json
+++ b/devvit.json
@@ -45,7 +45,9 @@
   "triggers": {
     "onAppInstall": "/internal/triggers/on-app-install",
     "onPostCreate": "/internal/triggers/on-post-create",
-    "onCommentCreate": "/internal/triggers/on-comment-create"
+    "onPostDelete": "/internal/triggers/on-post-delete",
+    "onCommentCreate": "/internal/triggers/on-comment-create",
+    "onCommentDelete": "/internal/triggers/on-comment-delete"
   },
   "scheduler": {
     "tasks": {

--- a/src/server/core/comment-cache.test.ts
+++ b/src/server/core/comment-cache.test.ts
@@ -5,7 +5,12 @@ import {
   COMMENT_GIF_PREVIEW_MARKER,
   COMMENT_IMAGE_PREVIEW_MARKER,
 } from '../../shared/api';
-import { createDataLayer, getDataKeys, type RedisDataClient } from '../data';
+import {
+  DATA_RETENTION_TTL_SECONDS,
+  createDataLayer,
+  getDataKeys,
+  type RedisDataClient,
+} from '../data';
 import {
   processCommentCacheQueue,
   refreshCommentCache,
@@ -14,8 +19,31 @@ import {
 } from './comment-cache';
 
 class FakeRedisClient implements RedisDataClient {
+  readonly expireCalls: Array<{ key: string; seconds: number }> = [];
   readonly hashes = new Map<string, Map<string, string>>();
   readonly sortedSets = new Map<string, Map<string, number>>();
+
+  async expire(key: string, seconds: number): Promise<void> {
+    this.expireCalls.push({ key, seconds });
+  }
+
+  async hDel(key: string, fields: string[]): Promise<number> {
+    const hash = this.hashes.get(key);
+
+    if (!hash) {
+      return 0;
+    }
+
+    let removedFieldCount = 0;
+
+    fields.forEach((field) => {
+      if (hash.delete(field)) {
+        removedFieldCount += 1;
+      }
+    });
+
+    return removedFieldCount;
+  }
 
   async hGet(key: string, field: string): Promise<string | undefined> {
     return this.hashes.get(key)?.get(field);
@@ -194,6 +222,16 @@ test('refreshCommentCache resets queues and seeds post ids with timestamp batch 
     redisClient.readSortedSet(keys.commentRefreshCommentQueue),
     []
   );
+  assert.deepEqual(redisClient.expireCalls, [
+    {
+      key: keys.commentRefreshPostQueue,
+      seconds: DATA_RETENTION_TTL_SECONDS,
+    },
+    {
+      key: keys.commentRefreshCommentQueue,
+      seconds: DATA_RETENTION_TTL_SECONDS,
+    },
+  ]);
 });
 
 test('processCommentCacheQueue prefers comment queue items before post queue items', async () => {
@@ -301,6 +339,24 @@ test('processCommentCacheQueue caches post comments and fetches child comments w
         bodyPreview: 'Child body',
       },
     ]
+  );
+  assert.deepEqual(
+    await dataLayer.commentPostIndex.getCommentIds('t3_post_1'),
+    ['t1_parent', 't1_child']
+  );
+  assert.ok(
+    redisClient.expireCalls.some(
+      ({ key, seconds }) =>
+        key === keys.commentRefreshPostQueue &&
+        seconds === DATA_RETENTION_TTL_SECONDS
+    )
+  );
+  assert.ok(
+    redisClient.expireCalls.some(
+      ({ key, seconds }) =>
+        key === keys.commentRefreshCommentQueue &&
+        seconds === DATA_RETENTION_TTL_SECONDS
+    )
   );
 });
 

--- a/src/server/core/comment-cache.ts
+++ b/src/server/core/comment-cache.ts
@@ -7,6 +7,7 @@ import {
   type ChartComment,
 } from '../../shared/api';
 import { createDataLayer, getDataKeys, type DataLayer } from '../data';
+import { retainRedisKeys } from '../data';
 import type { CommentEntity, HydratedComment } from '../data';
 import { createLogger } from '../logging/logger';
 import { readLatestCachedPostIds } from './post-cache';
@@ -24,7 +25,7 @@ type CommentId = `t1_${string}`;
 type CommentQueueMember = `${PostId}:${CommentId}`;
 type CommentRefreshQueueRedisClient = Pick<
   typeof redis,
-  'del' | 'zAdd' | 'zRange' | 'zRem'
+  'del' | 'expire' | 'zAdd' | 'zRange' | 'zRem'
 >;
 type CommentRefreshRedditClient = Pick<typeof reddit, 'getComments'>;
 
@@ -174,6 +175,10 @@ export const refreshCommentCache = async (
       parentPostIds,
       now()
     );
+    await retainRedisKeys(redisClient, [
+      queueKeys.postQueue,
+      queueKeys.commentQueue,
+    ]);
 
     const result = {
       parentPostCount: parentPostIds.length,
@@ -274,6 +279,10 @@ export const processCommentCacheQueue = async (
     }
 
     result.generatedAt = new Date(now()).toISOString();
+    await retainRedisKeys(redisClient, [
+      queueKeys.postQueue,
+      queueKeys.commentQueue,
+    ]);
 
     logger.info('Processed comment cache refresh queue', {
       subredditName,
@@ -438,16 +447,21 @@ const refreshQueuedCommentParent = async ({
 
     const commentEntities = comments.map(toCommentEntity);
 
-    await dataLayer.comments.upsertMany(commentEntities);
-
-    const enqueuedCommentParentCount = await enqueueQueueItems(
-      redisClient,
-      queueKeys.commentQueue,
-      comments
-        .map((comment) => createCommentQueueMember(comment.postId, comment.id))
-        .filter((member): member is CommentQueueMember => member !== null),
-      now()
-    );
+    const commentIds = commentEntities.map((comment) => comment.id);
+    const enqueuedCommentParentCount = await Promise.all([
+      dataLayer.comments.upsertMany(commentEntities),
+      dataLayer.commentPostIndex.addCommentIds(item.postId, commentIds),
+      enqueueQueueItems(
+        redisClient,
+        queueKeys.commentQueue,
+        comments
+          .map((comment) =>
+            createCommentQueueMember(comment.postId, comment.id)
+          )
+          .filter((member): member is CommentQueueMember => member !== null),
+        now()
+      ),
+    ]).then(([, , enqueuedCount]) => enqueuedCount);
 
     return {
       fetchedCommentCount: comments.length,

--- a/src/server/core/contributor-cache.test.ts
+++ b/src/server/core/contributor-cache.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { reddit } from '@devvit/web/server';
 import { beforeEach, expect, test, vi } from 'vitest';
 import {
+  DATA_RETENTION_TTL_SECONDS,
   createDataLayer,
   getDataKeys,
   type CommentEntity,
@@ -27,8 +28,31 @@ vi.mock('@devvit/web/server', () => ({
 }));
 
 class FakeRedisClient implements RedisDataClient {
+  readonly expireCalls: Array<{ key: string; seconds: number }> = [];
   readonly hashes = new Map<string, Map<string, string>>();
   readonly sortedSets = new Map<string, Map<string, number>>();
+
+  async expire(key: string, seconds: number): Promise<void> {
+    this.expireCalls.push({ key, seconds });
+  }
+
+  async hDel(key: string, fields: string[]): Promise<number> {
+    const hash = this.hashes.get(key);
+
+    if (!hash) {
+      return 0;
+    }
+
+    let removedFieldCount = 0;
+
+    fields.forEach((field) => {
+      if (hash.delete(field)) {
+        removedFieldCount += 1;
+      }
+    });
+
+    return removedFieldCount;
+  }
 
   async hGet(key: string, field: string): Promise<string | undefined> {
     return this.hashes.get(key)?.get(field);
@@ -199,6 +223,10 @@ test('refreshContributorCache replaces stale queue entries and orders contributo
     { member: 'carol', score: 1 },
     { member: 'alice', score: 2 },
   ]);
+  assert.deepEqual(redisClient.expireCalls.at(-1), {
+    key: keys.contributorRefreshQueue,
+    seconds: DATA_RETENTION_TTL_SECONDS,
+  });
 });
 
 test('processContributorCacheQueue refreshes contributors in queue order until empty', async () => {
@@ -245,6 +273,10 @@ test('processContributorCacheQueue refreshes contributors in queue order until e
     invalidQueueItemCount: 0,
     queueEmpty: true,
     generatedAt: '1970-01-01T00:00:00.000Z',
+  });
+  assert.deepEqual(redisClient.expireCalls.at(-1), {
+    key: getDataKeys('ExampleSub').contributorRefreshQueue,
+    seconds: DATA_RETENTION_TTL_SECONDS,
   });
 });
 
@@ -431,6 +463,8 @@ const createContributorRepository = (
     await onUpsert(contributor);
   },
   upsertMany: async () => {},
+  delete: async () => {},
+  deleteMany: async () => {},
 });
 
 const createPost = (

--- a/src/server/core/contributor-cache.ts
+++ b/src/server/core/contributor-cache.ts
@@ -1,6 +1,7 @@
 import { context, reddit, redis } from '@devvit/web/server';
 import { resolveUserAvatarUrl } from '../../shared/api';
 import { createDataLayer, getDataKeys } from '../data';
+import { retainRedisKeys } from '../data';
 import type {
   ContributorEntity,
   CommentEntity,
@@ -20,7 +21,7 @@ const REDIS_QUEUE_CHUNK_SIZE = 100;
 
 type ContributorRefreshQueueRedisClient = Pick<
   typeof redis,
-  'del' | 'zAdd' | 'zRange' | 'zRem'
+  'del' | 'expire' | 'zAdd' | 'zRange' | 'zRem'
 >;
 
 type ContributorQueueSeedCandidate = {
@@ -126,6 +127,7 @@ export const refreshContributorCache = async (
       queueKey,
       candidates.map(({ username }) => username)
     );
+    await retainRedisKeys(redisClient, [queueKey]);
     const result = {
       candidateContributorCount: candidates.length,
       enqueuedContributorCount,
@@ -223,6 +225,7 @@ export const processContributorCacheQueue = async (
     }
 
     result.generatedAt = new Date(now()).toISOString();
+    await retainRedisKeys(redisClient, [queueKey]);
 
     logger.info('Processed contributor cache refresh queue', {
       subredditName,

--- a/src/server/core/event-cache.test.ts
+++ b/src/server/core/event-cache.test.ts
@@ -5,7 +5,9 @@ import {
   SubredditRating,
   SubredditType,
   type CommentV2,
+  type OnCommentDeleteRequest,
   type OnCommentCreateRequest,
+  type OnPostDeleteRequest,
   type OnPostCreateRequest,
   type PostV2,
   type SubredditV2,
@@ -16,12 +18,34 @@ import { createDataLayer, type RedisDataClient } from '../data';
 import {
   cacheCommentCreateEvent,
   cachePostCreateEvent,
+  deleteCommentCacheEvent,
+  deletePostCacheEvent,
   type EventCacheDependencies,
 } from './event-cache';
 
 class FakeRedisDataClient implements RedisDataClient {
   readonly hashes = new Map<string, Map<string, string>>();
   readonly sortedSets = new Map<string, Map<string, number>>();
+
+  async expire(_key: string, _seconds: number): Promise<void> {}
+
+  async hDel(key: string, fields: string[]): Promise<number> {
+    const hash = this.hashes.get(key);
+
+    if (!hash) {
+      return 0;
+    }
+
+    let removedFieldCount = 0;
+
+    fields.forEach((field) => {
+      if (hash.delete(field)) {
+        removedFieldCount += 1;
+      }
+    });
+
+    return removedFieldCount;
+  }
 
   async hGet(key: string, field: string): Promise<string | undefined> {
     return this.hashes.get(key)?.get(field);
@@ -69,6 +93,24 @@ class FakeRedisDataClient implements RedisDataClient {
 
     this.sortedSets.set(key, sortedSet);
     return addedMemberCount;
+  }
+
+  async zRem(key: string, members: string[]): Promise<number> {
+    const sortedSet = this.sortedSets.get(key);
+
+    if (!sortedSet) {
+      return 0;
+    }
+
+    let removedMemberCount = 0;
+
+    members.forEach((member) => {
+      if (sortedSet.delete(member)) {
+        removedMemberCount += 1;
+      }
+    });
+
+    return removedMemberCount;
   }
 
   async zRange(
@@ -383,6 +425,117 @@ test('deleted authors are cached without contributor metadata refresh', async ()
   assert.deepEqual(contributorRefreshCalls, []);
 });
 
+test('post delete events remove cached posts and their indexed comments', async () => {
+  const redisClient = new FakeRedisDataClient();
+  const dataLayer = createDataLayer('examplesub', redisClient);
+  const contributorRefreshCalls: ContributorRefreshCall[] = [];
+  const dependencies = createDependencies(redisClient, contributorRefreshCalls);
+
+  await dataLayer.posts.upsert({
+    id: 't3_post_1',
+    title: 'Original post',
+    authorName: 'post-author',
+    comments: 2,
+    score: 10,
+    createdAt: '2026-04-15T09:00:00.000Z',
+    permalink: '/r/ExampleSub/comments/post_1/original_post/',
+  });
+  await dataLayer.comments.upsertMany([
+    {
+      id: 't1_comment_1',
+      postId: 't3_post_1',
+      authorName: 'alice',
+      score: 4,
+      bodyPreview: 'First comment',
+      createdAt: '2026-04-15T10:00:00.000Z',
+      permalink: '/r/ExampleSub/comments/post_1/comment_1/',
+    },
+    {
+      id: 't1_comment_2',
+      postId: 't3_post_1',
+      authorName: 'bob',
+      score: 5,
+      bodyPreview: 'Second comment',
+      createdAt: '2026-04-15T10:05:00.000Z',
+      permalink: '/r/ExampleSub/comments/post_1/comment_2/',
+    },
+  ]);
+  await dataLayer.commentPostIndex.addCommentIds('t3_post_1', [
+    't1_comment_1',
+    't1_comment_2',
+  ]);
+
+  const result = await deletePostCacheEvent(
+    createPostDeleteRequest(),
+    dependencies
+  );
+
+  assert.deepEqual(result, {
+    status: 'deleted',
+    subredditName: 'examplesub',
+    deletedPostCount: 1,
+    deletedCommentCount: 2,
+    generatedAt: '2026-04-15T12:00:00.000Z',
+  });
+  assert.equal(await dataLayer.posts.getById('t3_post_1'), null);
+  assert.equal(await dataLayer.comments.getById('t1_comment_1'), null);
+  assert.equal(await dataLayer.comments.getById('t1_comment_2'), null);
+  assert.deepEqual(
+    await dataLayer.commentPostIndex.getCommentIds('t3_post_1'),
+    []
+  );
+});
+
+test('comment delete events remove cached comments and update the post index', async () => {
+  const redisClient = new FakeRedisDataClient();
+  const dataLayer = createDataLayer('examplesub', redisClient);
+  const contributorRefreshCalls: ContributorRefreshCall[] = [];
+  const dependencies = createDependencies(redisClient, contributorRefreshCalls);
+
+  await dataLayer.comments.upsertMany([
+    {
+      id: 't1_comment_1',
+      postId: 't3_post_1',
+      authorName: 'alice',
+      score: 4,
+      bodyPreview: 'First comment',
+      createdAt: '2026-04-15T10:00:00.000Z',
+      permalink: '/r/ExampleSub/comments/post_1/comment_1/',
+    },
+    {
+      id: 't1_comment_2',
+      postId: 't3_post_1',
+      authorName: 'bob',
+      score: 5,
+      bodyPreview: 'Second comment',
+      createdAt: '2026-04-15T10:05:00.000Z',
+      permalink: '/r/ExampleSub/comments/post_1/comment_2/',
+    },
+  ]);
+  await dataLayer.commentPostIndex.addCommentIds('t3_post_1', [
+    't1_comment_1',
+    't1_comment_2',
+  ]);
+
+  const result = await deleteCommentCacheEvent(
+    createCommentDeleteRequest(),
+    dependencies
+  );
+
+  assert.deepEqual(result, {
+    status: 'deleted',
+    subredditName: 'examplesub',
+    deletedPostCount: 0,
+    deletedCommentCount: 1,
+    generatedAt: '2026-04-15T12:00:00.000Z',
+  });
+  assert.equal(await dataLayer.comments.getById('t1_comment_1'), null);
+  assert.deepEqual(
+    await dataLayer.commentPostIndex.getCommentIds('t3_post_1'),
+    ['t1_comment_2']
+  );
+});
+
 const createDependencies = (
   redisClient: RedisDataClient,
   contributorRefreshCalls: ContributorRefreshCall[],
@@ -433,6 +586,40 @@ const createCommentCreateRequest = ({
   comment,
   post,
   author,
+  subreddit,
+});
+
+const createPostDeleteRequest = ({
+  postId = 'post_1',
+  subreddit = createEventSubreddit(),
+}: {
+  postId?: string;
+  subreddit?: SubredditV2 | undefined;
+} = {}): OnPostDeleteRequest => ({
+  type: 'PostDelete',
+  postId,
+  deletedAt: '2026-04-15T12:00:00.000Z',
+  source: 0,
+  reason: 0,
+  subreddit,
+});
+
+const createCommentDeleteRequest = ({
+  commentId = 'comment_1',
+  postId = 'post_1',
+  subreddit = createEventSubreddit(),
+}: {
+  commentId?: string;
+  postId?: string;
+  subreddit?: SubredditV2 | undefined;
+} = {}): OnCommentDeleteRequest => ({
+  type: 'CommentDelete',
+  commentId,
+  postId,
+  parentId: 't3_post_1',
+  deletedAt: '2026-04-15T12:00:00.000Z',
+  source: 0,
+  reason: 0,
   subreddit,
 });
 

--- a/src/server/core/event-cache.ts
+++ b/src/server/core/event-cache.ts
@@ -1,7 +1,9 @@
 import { context, reddit } from '@devvit/web/server';
 import type {
   CommentV2,
+  OnCommentDeleteRequest,
   OnCommentCreateRequest,
+  OnPostDeleteRequest,
   OnPostCreateRequest,
   PostV2,
   SubredditV2,
@@ -21,7 +23,10 @@ import { normalizeSubredditName } from './subreddits';
 const logger = createLogger('event-cache');
 const SECONDS_TIMESTAMP_THRESHOLD = 10_000_000_000;
 
-type EventDataLayer = Pick<DataLayer, 'posts' | 'comments'>;
+type EventDataLayer = Pick<
+  DataLayer,
+  'commentPostIndex' | 'posts' | 'comments'
+>;
 
 type EventContributorRefreshOptions = {
   subredditName: string;
@@ -48,6 +53,15 @@ export type EventCacheResult = {
   cachedPostCount: number;
   cachedCommentCount: number;
   refreshedContributorCount: number;
+  generatedAt: string;
+  skippedReason?: string;
+};
+
+export type EventDeleteResult = {
+  status: 'deleted' | 'skipped';
+  subredditName: string;
+  deletedPostCount: number;
+  deletedCommentCount: number;
   generatedAt: string;
   skippedReason?: string;
 };
@@ -133,6 +147,7 @@ export const cacheCommentCreateEvent = async (
   const [parentPostCached] = await Promise.all([
     upsertExistingParentPostFromEvent(input.post, dataLayer),
     dataLayer.comments.upsert(comment),
+    dataLayer.commentPostIndex.addCommentIds(comment.postId, [comment.id]),
   ]);
   const refreshedContributorCount = await refreshContributorForAuthor({
     subredditName,
@@ -146,6 +161,85 @@ export const cacheCommentCreateEvent = async (
     cachedPostCount: parentPostCached ? 1 : 0,
     cachedCommentCount: 1,
     refreshedContributorCount,
+    generatedAt: now().toISOString(),
+  };
+};
+
+export const deletePostCacheEvent = async (
+  input: OnPostDeleteRequest,
+  {
+    createDataLayerForSubreddit = createDataLayer,
+    currentSubredditName = context.subredditName,
+    now = () => new Date(),
+  }: EventCacheDependencies = {}
+): Promise<EventDeleteResult> => {
+  const subredditName = resolveEventSubredditName(
+    input.subreddit,
+    currentSubredditName
+  );
+  const postId = normalizeThingId(input.postId, 't3_');
+
+  if (!postId) {
+    return createSkippedEventDeleteResult({
+      subredditName,
+      skippedReason: 'missing_or_invalid_post_delete_payload',
+      now,
+    });
+  }
+
+  const dataLayer = createDataLayerForSubreddit(subredditName);
+  const commentIds = await dataLayer.commentPostIndex.getCommentIds(postId);
+
+  await Promise.all([
+    dataLayer.posts.delete(postId),
+    dataLayer.comments.deleteMany(commentIds),
+    dataLayer.commentPostIndex.delete(postId),
+  ]);
+
+  return {
+    status: 'deleted',
+    subredditName,
+    deletedPostCount: 1,
+    deletedCommentCount: commentIds.length,
+    generatedAt: now().toISOString(),
+  };
+};
+
+export const deleteCommentCacheEvent = async (
+  input: OnCommentDeleteRequest,
+  {
+    createDataLayerForSubreddit = createDataLayer,
+    currentSubredditName = context.subredditName,
+    now = () => new Date(),
+  }: EventCacheDependencies = {}
+): Promise<EventDeleteResult> => {
+  const subredditName = resolveEventSubredditName(
+    input.subreddit,
+    currentSubredditName
+  );
+  const commentId = normalizeThingId(input.commentId, 't1_');
+  const postId = normalizeThingId(input.postId, 't3_');
+
+  if (!commentId || !postId) {
+    return createSkippedEventDeleteResult({
+      subredditName,
+      skippedReason: 'missing_or_invalid_comment_delete_payload',
+      now,
+    });
+  }
+
+  const dataLayer = createDataLayerForSubreddit(subredditName);
+
+  await Promise.all([
+    dataLayer.comments.delete(commentId),
+    dataLayer.commentPostIndex.removeCommentIds(postId, [commentId]),
+  ]);
+
+  return {
+    status: 'deleted',
+    subredditName,
+    deletedPostCount: 0,
+    deletedCommentCount: 1,
     generatedAt: now().toISOString(),
   };
 };
@@ -404,6 +498,23 @@ const createSkippedEventCacheResult = ({
   cachedPostCount: 0,
   cachedCommentCount: 0,
   refreshedContributorCount: 0,
+  generatedAt: now().toISOString(),
+  skippedReason,
+});
+
+const createSkippedEventDeleteResult = ({
+  subredditName,
+  skippedReason,
+  now,
+}: {
+  subredditName: string;
+  skippedReason: string;
+  now: () => Date;
+}): EventDeleteResult => ({
+  status: 'skipped',
+  subredditName,
+  deletedPostCount: 0,
+  deletedCommentCount: 0,
   generatedAt: now().toISOString(),
   skippedReason,
 });

--- a/src/server/data/codecs.ts
+++ b/src/server/data/codecs.ts
@@ -89,6 +89,26 @@ export const contributorEntityCodec: EntityCodec<ContributorEntity> = {
   serialize: JSON.stringify,
 };
 
+export const stringArrayCodec: EntityCodec<string[]> = {
+  parse(value) {
+    if (value === null || value === undefined) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(value) as unknown;
+
+      return Array.isArray(parsed) &&
+        parsed.every((item) => typeof item === 'string')
+        ? parsed
+        : [];
+    } catch {
+      return [];
+    }
+  },
+  serialize: JSON.stringify,
+};
+
 const parseJsonRecord = (
   value: string | null | undefined
 ): Record<string, unknown> | null => {

--- a/src/server/data/data-layer.test.ts
+++ b/src/server/data/data-layer.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import {
+  DATA_RETENTION_TTL_SECONDS,
   createDataLayer,
   getDataKeys,
   type ContributorEntity,
@@ -10,9 +11,32 @@ import {
 } from './index';
 
 class FakeRedisDataClient implements RedisDataClient {
+  readonly expireCalls: Array<{ key: string; seconds: number }> = [];
   readonly hMGetCalls: Array<{ key: string; fields: string[] }> = [];
   readonly hashes = new Map<string, Map<string, string>>();
   readonly sortedSets = new Map<string, Map<string, number>>();
+
+  async expire(key: string, seconds: number): Promise<void> {
+    this.expireCalls.push({ key, seconds });
+  }
+
+  async hDel(key: string, fields: string[]): Promise<number> {
+    const hash = this.hashes.get(key);
+
+    if (!hash) {
+      return 0;
+    }
+
+    let removedFieldCount = 0;
+
+    fields.forEach((field) => {
+      if (hash.delete(field)) {
+        removedFieldCount += 1;
+      }
+    });
+
+    return removedFieldCount;
+  }
 
   async hGet(key: string, field: string): Promise<string | undefined> {
     return this.hashes.get(key)?.get(field);
@@ -63,6 +87,24 @@ class FakeRedisDataClient implements RedisDataClient {
     return addedMemberCount;
   }
 
+  async zRem(key: string, members: string[]): Promise<number> {
+    const sortedSet = this.sortedSets.get(key);
+
+    if (!sortedSet) {
+      return 0;
+    }
+
+    let removedMemberCount = 0;
+
+    members.forEach((member) => {
+      if (sortedSet.delete(member)) {
+        removedMemberCount += 1;
+      }
+    });
+
+    return removedMemberCount;
+  }
+
   async zRange(
     key: string,
     start: number | string,
@@ -107,6 +149,7 @@ class FakeRedisDataClient implements RedisDataClient {
   }
 
   clearCallHistory(): void {
+    this.expireCalls.length = 0;
     this.hMGetCalls.length = 0;
   }
 }
@@ -117,6 +160,7 @@ test('data keys use app-local prefixes', () => {
     postCreatedAtIndex: 'data:v1:examplesub:posts:createdAt',
     comments: 'data:v1:examplesub:comments',
     commentCreatedAtIndex: 'data:v1:examplesub:comments:createdAt',
+    commentIdsByPost: 'data:v1:examplesub:comments:byPost',
     commentRefreshPostQueue: 'data:v1:examplesub:comments:refresh:posts',
     commentRefreshCommentQueue: 'data:v1:examplesub:comments:refresh:comments',
     contributors: 'data:v1:examplesub:contributors',
@@ -283,6 +327,133 @@ test('comment repositories parse comment previews without preview kind metadata'
   assert.deepEqual(await dataLayer.comments.getById(legacyComment.id), {
     ...legacyComment,
   });
+});
+
+test('repositories refresh data retention TTLs after writes', async () => {
+  const redisClient = new FakeRedisDataClient();
+  const dataLayer = createDataLayer('ExampleSub', redisClient);
+  const keys = getDataKeys('ExampleSub');
+
+  await dataLayer.posts.upsert(
+    createPost('t3_post_1', '2026-04-15T10:00:00.000Z')
+  );
+  await dataLayer.comments.upsert(
+    createComment('t1_comment_1', '2026-04-15T10:30:00.000Z')
+  );
+  await dataLayer.contributors.upsert(createContributor('alice'));
+  await dataLayer.commentPostIndex.addCommentIds('t3_post_1', [
+    't1_comment_1',
+    't1_comment_1',
+  ]);
+
+  assert.deepEqual(redisClient.expireCalls, [
+    { key: keys.posts, seconds: DATA_RETENTION_TTL_SECONDS },
+    {
+      key: keys.postCreatedAtIndex,
+      seconds: DATA_RETENTION_TTL_SECONDS,
+    },
+    { key: keys.comments, seconds: DATA_RETENTION_TTL_SECONDS },
+    {
+      key: keys.commentCreatedAtIndex,
+      seconds: DATA_RETENTION_TTL_SECONDS,
+    },
+    { key: keys.contributors, seconds: DATA_RETENTION_TTL_SECONDS },
+    { key: keys.commentIdsByPost, seconds: DATA_RETENTION_TTL_SECONDS },
+  ]);
+});
+
+test('repositories delete cached entities and remove sorted set members', async () => {
+  const redisClient = new FakeRedisDataClient();
+  const dataLayer = createDataLayer('ExampleSub', redisClient);
+  const keys = getDataKeys('ExampleSub');
+  const startTime = Date.parse('2026-04-15T09:00:00.000Z');
+  const endTime = Date.parse('2026-04-15T13:00:00.000Z');
+
+  await dataLayer.posts.upsertMany([
+    createPost('t3_post_1', '2026-04-15T10:00:00.000Z'),
+    createPost('t3_post_2', '2026-04-15T12:00:00.000Z'),
+  ]);
+  await dataLayer.comments.upsertMany([
+    createComment('t1_comment_1', '2026-04-15T10:30:00.000Z'),
+    createComment('t1_comment_2', '2026-04-15T11:30:00.000Z'),
+  ]);
+  await dataLayer.contributors.upsertMany([
+    createContributor('alice'),
+    createContributor('bob'),
+  ]);
+  await dataLayer.commentPostIndex.addCommentIds('t3_post_1', [
+    't1_comment_1',
+    't1_comment_2',
+  ]);
+  redisClient.clearCallHistory();
+
+  await dataLayer.posts.delete('t3_post_1');
+  await dataLayer.comments.deleteMany(['t1_comment_1']);
+  await dataLayer.contributors.delete('alice');
+  await dataLayer.commentPostIndex.removeCommentIds('t3_post_1', [
+    't1_comment_1',
+  ]);
+  await dataLayer.commentPostIndex.delete('t3_missing');
+
+  assert.equal(await dataLayer.posts.getById('t3_post_1'), null);
+  assert.deepEqual(
+    await dataLayer.posts.getIdsInTimeRange({ startTime, endTime }),
+    ['t3_post_2']
+  );
+  assert.equal(await dataLayer.comments.getById('t1_comment_1'), null);
+  assert.deepEqual(
+    await dataLayer.comments.getIdsInTimeRange({ startTime, endTime }),
+    ['t1_comment_2']
+  );
+  assert.equal(await dataLayer.contributors.getById('alice'), null);
+  assert.deepEqual(
+    await dataLayer.commentPostIndex.getCommentIds('t3_post_1'),
+    ['t1_comment_2']
+  );
+  assert.deepEqual(redisClient.expireCalls, [
+    { key: keys.posts, seconds: DATA_RETENTION_TTL_SECONDS },
+    {
+      key: keys.postCreatedAtIndex,
+      seconds: DATA_RETENTION_TTL_SECONDS,
+    },
+    { key: keys.comments, seconds: DATA_RETENTION_TTL_SECONDS },
+    {
+      key: keys.commentCreatedAtIndex,
+      seconds: DATA_RETENTION_TTL_SECONDS,
+    },
+    { key: keys.contributors, seconds: DATA_RETENTION_TTL_SECONDS },
+    { key: keys.commentIdsByPost, seconds: DATA_RETENTION_TTL_SECONDS },
+    { key: keys.commentIdsByPost, seconds: DATA_RETENTION_TTL_SECONDS },
+  ]);
+});
+
+test('comment post index stores deduplicated ids and supports delete', async () => {
+  const redisClient = new FakeRedisDataClient();
+  const dataLayer = createDataLayer('ExampleSub', redisClient);
+
+  await dataLayer.commentPostIndex.addCommentIds('t3_post_1', [
+    't1_comment_1',
+    't1_comment_2',
+    't1_comment_1',
+  ]);
+  assert.deepEqual(
+    await dataLayer.commentPostIndex.getCommentIds('t3_post_1'),
+    ['t1_comment_1', 't1_comment_2']
+  );
+
+  await dataLayer.commentPostIndex.removeCommentIds('t3_post_1', [
+    't1_comment_2',
+  ]);
+  assert.deepEqual(
+    await dataLayer.commentPostIndex.getCommentIds('t3_post_1'),
+    ['t1_comment_1']
+  );
+
+  await dataLayer.commentPostIndex.delete('t3_post_1');
+  assert.deepEqual(
+    await dataLayer.commentPostIndex.getCommentIds('t3_post_1'),
+    []
+  );
 });
 
 test('time indexed repositories read latest ids in newest-first order', async () => {

--- a/src/server/data/index.ts
+++ b/src/server/data/index.ts
@@ -1,4 +1,5 @@
 import {
+  createCommentPostIndexRepository,
   createContributorRepository,
   createCommentRepository,
   createPostRepository,
@@ -6,12 +7,14 @@ import {
 import { createRelationHydrators, type RelationHydrators } from './relations';
 import type { RedisDataClient } from './redis-repository';
 import type {
+  CommentPostIndexRepository,
   ContributorRepository,
   CommentRepository,
   PostRepository,
 } from './types';
 
 export type {
+  CommentPostIndexRepository,
   ContributorEntity,
   ContributorRepository,
   CommentEntity,
@@ -32,17 +35,20 @@ export type {
 export type { RedisDataClient } from './redis-repository';
 
 export {
+  createCommentPostIndexRepository,
   createContributorRepository,
   createCommentRepository,
   createPostRepository,
 } from './repositories';
 export { createRelationHydrators } from './relations';
 export { getDataKeys } from './keys';
+export { DATA_RETENTION_TTL_SECONDS, retainRedisKeys } from './retention';
 
 export type DataLayer = RelationHydrators & {
   posts: PostRepository;
   comments: CommentRepository;
   contributors: ContributorRepository;
+  commentPostIndex: CommentPostIndexRepository;
 };
 
 export const createDataLayer = (
@@ -52,12 +58,17 @@ export const createDataLayer = (
   const posts = createPostRepository(subredditName, redisClient);
   const comments = createCommentRepository(subredditName, redisClient);
   const contributors = createContributorRepository(subredditName, redisClient);
+  const commentPostIndex = createCommentPostIndexRepository(
+    subredditName,
+    redisClient
+  );
   const hydrators = createRelationHydrators({ posts, contributors });
 
   return {
     posts,
     comments,
     contributors,
+    commentPostIndex,
     ...hydrators,
   };
 };

--- a/src/server/data/keys.ts
+++ b/src/server/data/keys.ts
@@ -7,6 +7,7 @@ export type DataKeys = {
   postCreatedAtIndex: string;
   comments: string;
   commentCreatedAtIndex: string;
+  commentIdsByPost: string;
   commentRefreshPostQueue: string;
   commentRefreshCommentQueue: string;
   contributors: string;
@@ -21,6 +22,7 @@ export const getDataKeys = (subredditName: string): DataKeys => {
     postCreatedAtIndex: `${baseKey}:posts:createdAt`,
     comments: `${baseKey}:comments`,
     commentCreatedAtIndex: `${baseKey}:comments:createdAt`,
+    commentIdsByPost: `${baseKey}:comments:byPost`,
     commentRefreshPostQueue: `${baseKey}:comments:refresh:posts`,
     commentRefreshCommentQueue: `${baseKey}:comments:refresh:comments`,
     contributors: `${baseKey}:contributors`,

--- a/src/server/data/redis-repository.ts
+++ b/src/server/data/redis-repository.ts
@@ -1,6 +1,8 @@
 import { redis } from '@devvit/web/server';
 import type { EntityCodec } from './codecs';
+import { retainRedisKeys } from './retention';
 import type {
+  CommentPostIndexRepository,
   EntityRepository,
   TimeIndexedEntityRepository,
   TimeRange,
@@ -11,7 +13,7 @@ const REDIS_RANGE_READ_CHUNK_SIZE = 1000;
 
 export type RedisDataClient = Pick<
   typeof redis,
-  'hGet' | 'hMGet' | 'hSet' | 'zAdd' | 'zRange'
+  'expire' | 'hDel' | 'hGet' | 'hMGet' | 'hSet' | 'zAdd' | 'zRange' | 'zRem'
 >;
 
 type RedisHashRepositoryOptions<Entity> = {
@@ -60,8 +62,21 @@ export const createRedisHashRepository = <Entity>({
 
       if (Object.keys(fields).length > 0) {
         await redisClient.hSet(hashKey, fields);
+        await retainRedisKeys(redisClient, [hashKey]);
       }
     }
+  };
+
+  const deleteMany = async (ids: string[]): Promise<void> => {
+    if (ids.length === 0) {
+      return;
+    }
+
+    for (const chunk of chunkItems(uniqueItems(ids), REDIS_CHUNK_SIZE)) {
+      await redisClient.hDel(hashKey, chunk);
+    }
+
+    await retainRedisKeys(redisClient, [hashKey]);
   };
 
   return {
@@ -71,6 +86,10 @@ export const createRedisHashRepository = <Entity>({
       await upsertMany([entity]);
     },
     upsertMany,
+    async delete(id) {
+      await deleteMany([id]);
+    },
+    deleteMany,
   };
 };
 
@@ -116,8 +135,24 @@ export const createRedisTimeIndexedRepository = <Entity>({
           redisClient.hSet(hashKey, fields),
           redisClient.zAdd(indexKey, ...indexMembers),
         ]);
+        await retainRedisKeys(redisClient, [hashKey, indexKey]);
       }
     }
+  };
+
+  const deleteMany = async (ids: string[]): Promise<void> => {
+    if (ids.length === 0) {
+      return;
+    }
+
+    for (const chunk of chunkItems(uniqueItems(ids), REDIS_CHUNK_SIZE)) {
+      await Promise.all([
+        redisClient.hDel(hashKey, chunk),
+        redisClient.zRem(indexKey, chunk),
+      ]);
+    }
+
+    await retainRedisKeys(redisClient, [hashKey, indexKey]);
   };
 
   const getIdsInTimeRange = async ({
@@ -173,6 +208,10 @@ export const createRedisTimeIndexedRepository = <Entity>({
       await upsertMany([entity]);
     },
     upsertMany,
+    async delete(id) {
+      await deleteMany([id]);
+    },
+    deleteMany,
     getIdsInTimeRange,
     getLatestIds,
     async getInTimeRange(range) {
@@ -180,6 +219,75 @@ export const createRedisTimeIndexedRepository = <Entity>({
     },
   };
 };
+
+export const createRedisCommentPostIndexRepository = ({
+  redisClient = redis,
+  hashKey,
+  codec,
+}: {
+  redisClient?: RedisDataClient;
+  hashKey: string;
+  codec: EntityCodec<string[]>;
+}): CommentPostIndexRepository => ({
+  async getCommentIds(postId) {
+    return codec.parse(await redisClient.hGet(hashKey, postId)) ?? [];
+  },
+
+  async addCommentIds(postId, commentIds) {
+    const uniqueCommentIds = uniqueItems(commentIds);
+
+    if (uniqueCommentIds.length === 0) {
+      return;
+    }
+
+    const existingCommentIds =
+      codec.parse(await redisClient.hGet(hashKey, postId)) ?? [];
+    const nextCommentIds = uniqueItems([
+      ...existingCommentIds,
+      ...uniqueCommentIds,
+    ]);
+
+    await redisClient.hSet(hashKey, {
+      [postId]: codec.serialize(nextCommentIds),
+    });
+    await retainRedisKeys(redisClient, [hashKey]);
+  },
+
+  async removeCommentIds(postId, commentIds) {
+    const uniqueCommentIds = uniqueItems(commentIds);
+
+    if (uniqueCommentIds.length === 0) {
+      return;
+    }
+
+    const existingCommentIds =
+      codec.parse(await redisClient.hGet(hashKey, postId)) ?? [];
+
+    if (existingCommentIds.length === 0) {
+      return;
+    }
+
+    const commentIdsToRemove = new Set(uniqueCommentIds);
+    const remainingCommentIds = existingCommentIds.filter(
+      (commentId) => !commentIdsToRemove.has(commentId)
+    );
+
+    if (remainingCommentIds.length === 0) {
+      await redisClient.hDel(hashKey, [postId]);
+    } else {
+      await redisClient.hSet(hashKey, {
+        [postId]: codec.serialize(remainingCommentIds),
+      });
+    }
+
+    await retainRedisKeys(redisClient, [hashKey]);
+  },
+
+  async delete(postId) {
+    await redisClient.hDel(hashKey, [postId]);
+    await retainRedisKeys(redisClient, [hashKey]);
+  },
+});
 
 export const chunkItems = <Item>(items: Item[], size: number): Item[][] => {
   const chunks: Item[][] = [];
@@ -189,6 +297,22 @@ export const chunkItems = <Item>(items: Item[], size: number): Item[][] => {
   }
 
   return chunks;
+};
+
+const uniqueItems = <Item>(items: Item[]): Item[] => {
+  const seen = new Set<Item>();
+  const unique: Item[] = [];
+
+  items.forEach((item) => {
+    if (seen.has(item)) {
+      return;
+    }
+
+    seen.add(item);
+    unique.push(item);
+  });
+
+  return unique;
 };
 
 const createEntityFields = <Entity>(

--- a/src/server/data/repositories.ts
+++ b/src/server/data/repositories.ts
@@ -1,15 +1,18 @@
 import {
+  stringArrayCodec,
   contributorEntityCodec,
   commentEntityCodec,
   postEntityCodec,
 } from './codecs';
 import { getDataKeys } from './keys';
 import {
+  createRedisCommentPostIndexRepository,
   createRedisHashRepository,
   createRedisTimeIndexedRepository,
   type RedisDataClient,
 } from './redis-repository';
 import type {
+  CommentPostIndexRepository,
   ContributorRepository,
   CommentRepository,
   PostRepository,
@@ -58,5 +61,18 @@ export const createContributorRepository = (
     hashKey: keys.contributors,
     codec: contributorEntityCodec,
     getId: (contributor) => contributor.id,
+  });
+};
+
+export const createCommentPostIndexRepository = (
+  subredditName: string,
+  redisClient?: RedisDataClient
+): CommentPostIndexRepository => {
+  const keys = getDataKeys(subredditName);
+
+  return createRedisCommentPostIndexRepository({
+    redisClient,
+    hashKey: keys.commentIdsByPost,
+    codec: stringArrayCodec,
   });
 };

--- a/src/server/data/retention.ts
+++ b/src/server/data/retention.ts
@@ -1,0 +1,22 @@
+import type { redis } from '@devvit/web/server';
+
+export const DATA_RETENTION_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+type RedisRetentionClient = Pick<typeof redis, 'expire'>;
+
+export const retainRedisKeys = async (
+  redisClient: RedisRetentionClient,
+  keys: string[]
+): Promise<void> => {
+  const uniqueKeys = [...new Set(keys.filter((key) => key.trim() !== ''))];
+
+  if (uniqueKeys.length === 0) {
+    return;
+  }
+
+  await Promise.all(
+    uniqueKeys.map(async (key) => {
+      await redisClient.expire(key, DATA_RETENTION_TTL_SECONDS);
+    })
+  );
+};

--- a/src/server/data/types.ts
+++ b/src/server/data/types.ts
@@ -35,12 +35,21 @@ export type EntityRepository<Entity> = {
   getByIds(ids: string[]): Promise<Entity[]>;
   upsert(entity: Entity): Promise<void>;
   upsertMany(entities: Entity[]): Promise<void>;
+  delete(id: string): Promise<void>;
+  deleteMany(ids: string[]): Promise<void>;
 };
 
 export type TimeIndexedEntityRepository<Entity> = EntityRepository<Entity> & {
   getIdsInTimeRange(range: TimeRange): Promise<string[]>;
   getInTimeRange(range: TimeRange): Promise<Entity[]>;
   getLatestIds(limit: number): Promise<string[]>;
+};
+
+export type CommentPostIndexRepository = {
+  getCommentIds(postId: string): Promise<string[]>;
+  addCommentIds(postId: string, commentIds: string[]): Promise<void>;
+  removeCommentIds(postId: string, commentIds: string[]): Promise<void>;
+  delete(postId: string): Promise<void>;
 };
 
 export type PostRepository = TimeIndexedEntityRepository<PostEntity>;

--- a/src/server/routes/triggers.test.ts
+++ b/src/server/routes/triggers.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, expect, test, vi } from 'vitest';
 import {
   cacheCommentCreateEvent,
   cachePostCreateEvent,
+  deleteCommentCacheEvent,
+  deletePostCacheEvent,
 } from '../core/event-cache';
 import { triggers } from './triggers';
 
@@ -15,11 +17,15 @@ vi.mock('@devvit/web/server', () => ({
 vi.mock('../core/event-cache', () => ({
   cachePostCreateEvent: vi.fn(),
   cacheCommentCreateEvent: vi.fn(),
+  deletePostCacheEvent: vi.fn(),
+  deleteCommentCacheEvent: vi.fn(),
 }));
 
 beforeEach(() => {
   vi.mocked(cachePostCreateEvent).mockReset();
   vi.mocked(cacheCommentCreateEvent).mockReset();
+  vi.mocked(deletePostCacheEvent).mockReset();
+  vi.mocked(deleteCommentCacheEvent).mockReset();
 });
 
 test('post create trigger returns success after caching event data', async () => {
@@ -142,5 +148,75 @@ test('post create trigger returns an error response when caching fails', async (
   assert.deepEqual(body, {
     status: 'error',
     message: 'Failed to cache post create event',
+  });
+});
+
+test('post delete trigger returns success after deleting cached data', async () => {
+  vi.mocked(deletePostCacheEvent).mockResolvedValue({
+    status: 'deleted',
+    subredditName: 'examplesub',
+    deletedPostCount: 1,
+    deletedCommentCount: 2,
+    generatedAt: '2026-04-15T12:00:00.000Z',
+  });
+
+  const response = await triggers.request('/on-post-delete', {
+    method: 'POST',
+    body: JSON.stringify({
+      type: 'PostDelete',
+      postId: 'post_1',
+      subreddit: { name: 'ExampleSub' },
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  const body: unknown = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, {
+    status: 'success',
+    message: 'Post delete event removed cached data for r/examplesub',
+  });
+  expect(deletePostCacheEvent).toHaveBeenCalledWith({
+    type: 'PostDelete',
+    postId: 'post_1',
+    subreddit: { name: 'ExampleSub' },
+  });
+});
+
+test('comment delete trigger returns success after deleting cached data', async () => {
+  vi.mocked(deleteCommentCacheEvent).mockResolvedValue({
+    status: 'deleted',
+    subredditName: 'examplesub',
+    deletedPostCount: 0,
+    deletedCommentCount: 1,
+    generatedAt: '2026-04-15T12:00:00.000Z',
+  });
+
+  const response = await triggers.request('/on-comment-delete', {
+    method: 'POST',
+    body: JSON.stringify({
+      type: 'CommentDelete',
+      commentId: 'comment_1',
+      postId: 'post_1',
+      subreddit: { name: 'ExampleSub' },
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  const body: unknown = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, {
+    status: 'success',
+    message: 'Comment delete event removed cached data for r/examplesub',
+  });
+  expect(deleteCommentCacheEvent).toHaveBeenCalledWith({
+    type: 'CommentDelete',
+    commentId: 'comment_1',
+    postId: 'post_1',
+    subreddit: { name: 'ExampleSub' },
   });
 });

--- a/src/server/routes/triggers.ts
+++ b/src/server/routes/triggers.ts
@@ -1,7 +1,9 @@
 import { Hono } from 'hono';
 import type {
   OnAppInstallRequest,
+  OnCommentDeleteRequest,
   OnCommentCreateRequest,
+  OnPostDeleteRequest,
   OnPostCreateRequest,
   TriggerResponse,
 } from '@devvit/web/shared';
@@ -12,15 +14,20 @@ import {
 } from './cache';
 import {
   cacheCommentCreateEvent,
+  deleteCommentCacheEvent,
+  deletePostCacheEvent,
   cachePostCreateEvent,
   type EventCacheResult,
+  type EventDeleteResult,
 } from '../core/event-cache';
 import { createLogger } from '../logging/logger';
 
 export const triggers = new Hono();
 const appInstallLogger = createLogger('triggers:on-app-install');
 const postCreateLogger = createLogger('triggers:on-post-create');
+const postDeleteLogger = createLogger('triggers:on-post-delete');
 const commentCreateLogger = createLogger('triggers:on-comment-create');
+const commentDeleteLogger = createLogger('triggers:on-comment-delete');
 
 triggers.post('/on-app-install', async (c) => {
   const input = await c.req.json<OnAppInstallRequest>();
@@ -158,6 +165,102 @@ triggers.post('/on-comment-create', async (c) => {
   }
 });
 
+triggers.post('/on-post-delete', async (c) => {
+  const input = await c.req.json<OnPostDeleteRequest>();
+  postDeleteLogger.info('Received post delete trigger', {
+    currentSubredditName: context.subredditName,
+    triggerType: input.type,
+    eventSubredditName: input.subreddit?.name ?? null,
+    postId: input.postId ?? null,
+  });
+
+  try {
+    const result = await deletePostCacheEvent(input);
+
+    logEventDeleteResult(
+      postDeleteLogger,
+      'Completed post delete event cache update',
+      result
+    );
+
+    return c.json<TriggerResponse>(
+      {
+        status: 'success',
+        message:
+          result.status === 'deleted'
+            ? `Post delete event removed cached data for r/${result.subredditName}`
+            : `Post delete event skipped for r/${result.subredditName}`,
+      },
+      200
+    );
+  } catch (error) {
+    postDeleteLogger.error('Post delete event cache update failed', {
+      currentSubredditName: context.subredditName,
+      triggerType: input.type,
+      eventSubredditName: input.subreddit?.name ?? null,
+      postId: input.postId ?? null,
+      error: getErrorMessage(error),
+    });
+
+    return c.json<TriggerResponse>(
+      {
+        status: 'error',
+        message: 'Failed to delete cached post data',
+      },
+      500
+    );
+  }
+});
+
+triggers.post('/on-comment-delete', async (c) => {
+  const input = await c.req.json<OnCommentDeleteRequest>();
+  commentDeleteLogger.info('Received comment delete trigger', {
+    currentSubredditName: context.subredditName,
+    triggerType: input.type,
+    eventSubredditName: input.subreddit?.name ?? null,
+    postId: input.postId ?? null,
+    commentId: input.commentId ?? null,
+  });
+
+  try {
+    const result = await deleteCommentCacheEvent(input);
+
+    logEventDeleteResult(
+      commentDeleteLogger,
+      'Completed comment delete event cache update',
+      result
+    );
+
+    return c.json<TriggerResponse>(
+      {
+        status: 'success',
+        message:
+          result.status === 'deleted'
+            ? `Comment delete event removed cached data for r/${result.subredditName}`
+            : `Comment delete event skipped for r/${result.subredditName}`,
+      },
+      200
+    );
+  } catch (error) {
+    commentDeleteLogger.error('Comment delete event cache update failed', {
+      currentSubredditName: context.subredditName,
+      triggerType: input.type,
+      eventSubredditName: input.subreddit?.name ?? null,
+      postId: input.postId ?? null,
+      commentId: input.commentId ?? null,
+      error: getErrorMessage(error),
+    });
+
+    return c.json<TriggerResponse>(
+      {
+        status: 'error',
+        message: 'Failed to delete cached comment data',
+      },
+      500
+    );
+  }
+});
+
 const logEventCacheResult = (
   logger: ReturnType<typeof createLogger>,
   message: string,
@@ -170,6 +273,29 @@ const logEventCacheResult = (
     cachedPostCount: result.cachedPostCount,
     cachedCommentCount: result.cachedCommentCount,
     refreshedContributorCount: result.refreshedContributorCount,
+    generatedAt: result.generatedAt,
+    skippedReason: result.skippedReason ?? null,
+  };
+
+  if (result.status === 'skipped') {
+    logger.warn(message, metadata);
+    return;
+  }
+
+  logger.info(message, metadata);
+};
+
+const logEventDeleteResult = (
+  logger: ReturnType<typeof createLogger>,
+  message: string,
+  result: EventDeleteResult
+): void => {
+  const metadata = {
+    currentSubredditName: context.subredditName,
+    subredditName: result.subredditName,
+    status: result.status,
+    deletedPostCount: result.deletedPostCount,
+    deletedCommentCount: result.deletedCommentCount,
     generatedAt: result.generatedAt,
     skippedReason: result.skippedReason ?? null,
   };


### PR DESCRIPTION
## Summary
- Register post/comment delete triggers and route them through shared cache-deletion handlers.
- Add a comment-by-post index so post deletions can remove all cached comments without scanning the full cache.
- Introduce a 30-day Redis retention helper and apply it to subreddit-scoped cache writes and queue refreshes.

## Testing
- Added unit tests for data-layer deletes, comment index maintenance, delete-trigger handling, and TTL application.
- Ran targeted server test files, `type-check`, and `lint`; all passed.